### PR TITLE
Changed dyOutput call to include the model parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ the first loading)
 
 ``` r
 
-dyOutput(dvn1, con.fit.config, figtype = "unstandardized")
+dyOutput(dvn1, model="cfa", con.fit.config, figtype = "unstandardized")
 ```
 
 ![](img/table.png)


### PR DESCRIPTION
I believe the README has an incorrect call to dyOutput has the code defaults the value to NULL which is then compared to a string. This operator doesn't exist and will then fail when called.

README excerpt:
```
dyOutput(dvn1, con.fit.config, figtype = "unstandardized")
```

Code I tried:
```
    > dyOutput(dvn_xy, con.fit.config, figtype = "standardized")
    Error in model == "apim" : 
    comparison (1) is possible only for atomic and list types
```
dyOutput.R:
```
    dyOutput = function(dvn, model = NULL, // Setting model to NULL
    fit, table = TRUE, tabletype = NULL,
    figure = TRUE, figtype = NULL,
    dydMACS.x = NULL, dydMACS.y = NULL){
  dirs("output")
  if(model=="apim"){ // comparison
```

I made it work by using the 'model' parameter and setting to 'cfa' like this:
```
> dyOutput(dvn_xy, model = "cfa", con.fit.config, figtype = "standardized")
Output stored in [...]/output/figures/conconfigscript std.png
```

I think this provides more usable documentation, let me know what you think :)