### PR TITLE
add lavaan namespace to examples

### DIFF
--- a/R/getDyReliability.R
+++ b/R/getDyReliability.R
@@ -11,7 +11,7 @@
 #' @examples
 #' dvn <- scrapeVarCross(dat = DRES, x_order = "sip", x_stem = "PRQC", x_delim1 = "_", x_delim2=".", x_item_num="\\d+", distinguish_1="1", distinguish_2="2")
 #' qual.config.script <-  scriptCFA(dvn, lvname = "Qual", model = "configural")
-#' qual.config.mod <- cfa(qual.config.script, data = DRES, std.lv = F, auto.fix.first= F, meanstructure = T)
+#' qual.config.mod <- lavaan::cfa(qual.config.script, data = DRES, std.lv = F, auto.fix.first= F, meanstructure = T)
 #' getDyReliability(dvn, qual.config.mod)
 
 getDyReliability <- function(dvn, fit){

--- a/R/getDydmacs.R
+++ b/R/getDydmacs.R
@@ -13,7 +13,7 @@
 #' @examples
 #' dvn <- scrapeVarCross(dat = DRES, x_order = "sip", x_stem = "PRQC", x_delim1 = "_", x_delim2=".", x_item_num="\\d+", distinguish_1="1", distinguish_2="2")
 #' qual.config.script <-  scriptCFA(dvn, lvname = "Qual", model = "configural")
-#' qual.config.mod <- cfa(qual.config.script, data = DRES, std.lv = F, auto.fix.first= F, meanstructure = T)
+#' qual.config.mod <- lavaan::cfa(qual.config.script, data = DRES, std.lv = F, auto.fix.first= F, meanstructure = T)
 #' qual.dmacs <- getDydmacs(DRES, dvn, qual.config.mod)
 #'
 getDydmacs <- function(dat, dvn, fit, nodewidth = 0.01, lowerLV = -5, upperLV = 5){

--- a/R/getIndistFit.R
+++ b/R/getIndistFit.R
@@ -13,11 +13,11 @@
 #' @examples
 #' dvn <- scrapeVarCross(dat = DRES, x_order = "sip", x_stem = "PRQC", x_delim1 = "_", x_delim2=".", x_item_num="\\d+", distinguish_1="1", distinguish_2="2")
 #' qual.indist.script <-  scriptCFA(dvn, lvname = "Qual", model = "indist")
-#' qual.indist.mod <- cfa(qual.indist.script, data = DRES, std.lv = F, auto.fix.first= F, meanstructure = T)
+#' qual.indist.mod <- lavaan::cfa(qual.indist.script, data = DRES, std.lv = F, auto.fix.first= F, meanstructure = T)
 #' qual.isat.script <- scriptISAT(dvn, lvxname = "Qual")
-#' qual.isat.mod <- cfa(qual.isat.script, data = DRES, std.lv = F, auto.fix.first= F, meanstructure = T)
+#' qual.isat.mod <- lavaan::cfa(qual.isat.script, data = DRES, std.lv = F, auto.fix.first= F, meanstructure = T)
 #' qual.inull.script <- scriptINULL(dvn, lvxname = "Qual")
-#' qual.inull.mod <- cfa(qual.isat.script, data = DRES, std.lv = F, auto.fix.first= F, meanstructure = T)
+#' qual.inull.mod <- lavaan::cfa(qual.isat.script, data = DRES, std.lv = F, auto.fix.first= F, meanstructure = T)
 #' corr.fit <- getIndistFit(qual.indist.mod, qual.isat.mod, qual.inull.mod)
 #'
 getIndistFit <- function(indmodel, isatmod, inullmod){

--- a/man/getDyReliability.Rd
+++ b/man/getDyReliability.Rd
@@ -21,7 +21,7 @@ for each dyad member following Formula 2 in McNeish (2018).
 \examples{
 dvn <- scrapeVarCross(dat = DRES, x_order = "sip", x_stem = "PRQC", x_delim1 = "_", x_delim2=".", x_item_num="\\\\d+", distinguish_1="1", distinguish_2="2")
 qual.config.script <-  scriptCFA(dvn, lvname = "Qual", model = "configural")
-qual.config.mod <- cfa(qual.config.script, data = DRES, std.lv = F, auto.fix.first= F, meanstructure = T)
+qual.config.mod <- lavaan::cfa(qual.config.script, data = DRES, std.lv = F, auto.fix.first= F, meanstructure = T)
 getDyReliability(dvn, qual.config.mod)
 }
 \seealso{

--- a/man/getDydmacs.Rd
+++ b/man/getDydmacs.Rd
@@ -28,7 +28,7 @@ Calculates dmacs difference in expected indicator scores for between dyad member
 \examples{
 dvn <- scrapeVarCross(dat = DRES, x_order = "sip", x_stem = "PRQC", x_delim1 = "_", x_delim2=".", x_item_num="\\\\d+", distinguish_1="1", distinguish_2="2")
 qual.config.script <-  scriptCFA(dvn, lvname = "Qual", model = "configural")
-qual.config.mod <- cfa(qual.config.script, data = DRES, std.lv = F, auto.fix.first= F, meanstructure = T)
+qual.config.mod <- lavaan::cfa(qual.config.script, data = DRES, std.lv = F, auto.fix.first= F, meanstructure = T)
 qual.dmacs <- getDydmacs(DRES, dvn, qual.config.mod)
 
 }

--- a/man/getIndistFit.Rd
+++ b/man/getIndistFit.Rd
@@ -24,11 +24,11 @@ to the approach outlined by Olsen & Kenny (2006)
 \examples{
 dvn <- scrapeVarCross(dat = DRES, x_order = "sip", x_stem = "PRQC", x_delim1 = "_", x_delim2=".", x_item_num="\\\\d+", distinguish_1="1", distinguish_2="2")
 qual.indist.script <-  scriptCFA(dvn, lvname = "Qual", model = "indist")
-qual.indist.mod <- cfa(qual.indist.script, data = DRES, std.lv = F, auto.fix.first= F, meanstructure = T)
+qual.indist.mod <- lavaan::cfa(qual.indist.script, data = DRES, std.lv = F, auto.fix.first= F, meanstructure = T)
 qual.isat.script <- scriptISAT(dvn, lvxname = "Qual")
-qual.isat.mod <- cfa(qual.isat.script, data = DRES, std.lv = F, auto.fix.first= F, meanstructure = T)
+qual.isat.mod <- lavaan::cfa(qual.isat.script, data = DRES, std.lv = F, auto.fix.first= F, meanstructure = T)
 qual.inull.script <- scriptINULL(dvn, lvxname = "Qual")
-qual.inull.mod <- cfa(qual.isat.script, data = DRES, std.lv = F, auto.fix.first= F, meanstructure = T)
+qual.inull.mod <- lavaan::cfa(qual.isat.script, data = DRES, std.lv = F, auto.fix.first= F, meanstructure = T)
 corr.fit <- getIndistFit(qual.indist.mod, qual.isat.mod, qual.inull.mod)
 
 }


### PR DESCRIPTION
This namespace addition is also necessary for example code not to generate errors when run without the `lavaan` namespace loaded. Let me know if you'd prefer an initial `library(lavaan)` line instead, and I'll change accordingly.