### PR TITLE
docs: improve documentation.

### DIFF
--- a/R/scriptBiDy.R
+++ b/R/scriptBiDy.R
@@ -1,5 +1,5 @@
 #' A Function That Writes, Saves, and Exports Syntax for
-#' Fitting Bifactor Dyadic (Bidy) models
+#' Fitting Bifactor Dyadic (BiDy) models
 #'
 #' This function takes the outputted object from scrapeVarCross()
 #' and automatically writes, returns, and exports (.txt) lavaan() syntax


### PR DESCRIPTION
changed parenthetical "Bidy" to "BiDy" in the roxygen description.