### PR TITLE
docs: fixed esHelpers.R roxygen documentation.

### DIFF
--- a/R/esHelpers.R
+++ b/R/esHelpers.R
@@ -8,8 +8,17 @@
 #' @param fit outputted dyadic cfa lavaan object
 #' @param source character for whether parameter of interest should be extracted for group "1", "2", or from the "nogroup" model
 #' @family helpers
+#' @return a numeric vector containing the estimated values of the parameter of interest (e.g., loadings, intercepts, etc.) for the desired group.
 #'
 #' @export
+#' 
+#' @examples
+#' dvn <- scrapeVarCross(dat = commitmentQ, x_order = "spi", x_stem = "sat.g", x_delim1 = ".", 
+#' x_delim2="_", distinguish_1="1", distinguish_2="2")
+#' sat.config.script <-  scriptCFA(dvn, lvname = "Sat", model = "configural")
+#' sat.config.mod <- lavaan::cfa(sat.config.script, data = commitmentQ, std.lv = FALSE, 
+#' auto.fix.first= FALSE, meanstructure = TRUE)
+#' grouploads(sat.config.mod, dvn, "2")
 
 grouploads <- function(fit, dvn, source){
   if(source == "1"){

--- a/man/esHelpers.Rd
+++ b/man/esHelpers.Rd
@@ -28,7 +28,18 @@ grouplvsd(fit, source)
 
 \item{dat}{data frame of indicators}
 }
+\value{
+a numeric vector containing the estimated values of the parameter of interest (e.g., loadings, intercepts, etc.) for the desired group.
+}
 \description{
 Helper-functions for noninvariance effect size functions
+}
+\examples{
+dvn <- scrapeVarCross(dat = commitmentQ, x_order = "spi", x_stem = "sat.g", x_delim1 = ".", 
+x_delim2="_", distinguish_1="1", distinguish_2="2")
+sat.config.script <-  scriptCFA(dvn, lvname = "Sat", model = "configural")
+sat.config.mod <- lavaan::cfa(sat.config.script, data = commitmentQ, std.lv = FALSE, 
+auto.fix.first= FALSE, meanstructure = TRUE)
+grouploads(sat.config.mod, dvn, "2")
 }
 \concept{helpers}


### PR DESCRIPTION
#85

esHelpers.R appeared to have exported functionality but did not have a `@returns` value. And so, I added a `@returns` and, just in case, a `@examples` tag to the esHelpers.R documentation.

Lastly, I can confirm that all internal, non-exported functions have `@nord` tags. 