### PR TITLE
feat: added startup message.

### DIFF
--- a/R/startup.R
+++ b/R/startup.R
@@ -1,0 +1,5 @@
+.onAttach <- function(libname, pkgname) {
+  message <- c("\n Welcome to dySEM!",
+               "\n \n Happy coding!")
+  packageStartupMessage(message)
+}


### PR DESCRIPTION
#88 

Currently, the startup message just simply says:

<img width="923" alt="Screenshot 2023-10-17 at 2 51 29 PM" src="https://github.com/jsakaluk/dySEM/assets/124099458/17073f91-4734-42e8-ae3f-23cf6db388fe">

But, if you have a different startup message in mind, please let me know!

I also ended by running devtools::check() and did not receive any new complaints.

<img width="923" alt="Screenshot 2023-10-17 at 2 54 27 PM" src="https://github.com/jsakaluk/dySEM/assets/124099458/58f74add-b68e-4135-9ea2-3f207a4ab536">
