### PR TITLE
docs: updated DESCRIPTION and LICENSE (part of Issue #101).

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Authors@R: c(
     person("Robyn", "Kilshaw", , "robyn.bates@gmail.com", role = "ctb"),
     person("Alexandra", "Fisher", , "anfisher@uvic.ca", role = "ctb")
   )
-Description: Scripting of structural equation models via `lavaan` for
+Description: Scripting of structural equation models via 'lavaan' for
     Dyadic Data Analysis, and helper functions for supplemental
     calculations, tabling, and model visualization.  Current models
     supported include: Dyadic Confirmatory Factor Analysis, the Actor–Partner 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -553,7 +553,7 @@ and each file should have at least the “copyright” line and a pointer to
 where the full notice is found.
 
     <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) 2019 John K. Sakaluk
+    Copyright (C) 2023 John K. Sakaluk
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -573,7 +573,7 @@ Also add information on how to contact you by electronic and paper mail.
 If the program does terminal interaction, make it output a short notice like this
 when it starts in an interactive mode:
 
-    dySEM Copyright (C) 2019 John K. Sakaluk
+    dySEM Copyright (C) 2023 John K. Sakaluk
     This program comes with ABSOLUTELY NO WARRANTY; for details type 'show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type 'show c' for details.


### PR DESCRIPTION
Part of Issue #101 
Reviewed https://github.com/DavisVaughan/extrachecks 

CRAN may throw a flag for not single quoting software names in DESCRIPTION’s `description:` (also discussed in https://cran.r-project.org/web/packages/submission_checklist.html). The PR changes the back ticks around lavaan to single quotes ('lavaan'), just in case.

CRAN may throw a flag for not updating the year in the LICENSE file. The PR updates the license year to 2023, just in case. 