### PR TITLE
Fix: Purged dirs() in scripters and outputModel.R

### DIFF
--- a/R/outHelpers.R
+++ b/R/outHelpers.R
@@ -166,27 +166,55 @@ makeTable <- function(dvn, fit, model, tabletype){
 #' @rdname outHelpers
 #' @noRd
 
-makeFigure <- function(fit, type){
-  if(type == "raw"){
-    semplot <- semPlot::semPaths(fit, what = "est", whatLabels = "est", edge.label.cex = 0.5,
-                                 curvePivot = F, intercepts = F,
-                                 edge.color = "black", filetype = "png", filename = sprintf("output/figures/%s unstd", stringr::str_remove_all(as.character(fit@call$model), "[.]")
-                                 ), weighted = F,
-                                 edge.label.position = .3, nCharNodes = 0, fixedStyle = c("black", 2))
+makeFigure <- function(fit, type, writeout){
+  if(is.na(writeout)){
+    if(type == "raw"){
+      semplot <- semPlot::semPaths(fit, what = "est", whatLabels = "est", edge.label.cex = 0.5,
+                                   curvePivot = F, intercepts = F,
+                                   edge.color = "black", filetype = "png", filename = sprintf("output/figures/%s unstd", stringr::str_remove_all(as.character(fit@call$model), "[.]")
+                                   ), weighted = F,
+                                   edge.label.position = .3, nCharNodes = 0, fixedStyle = c("black", 2))
+    }
+    else if(type == "std"){
+      semplot <- semPlot::semPaths(fit, what = "std", whatLabels = "std", edge.label.cex = 0.5,
+                                   curvePivot = F, intercepts = F,
+                                   edge.color = "black", filetype = "png", filename = sprintf("output/figures/%s std", stringr::str_remove_all(as.character(fit@call$model), "[.]")
+                                   ), weighted = F,
+                                   edge.label.position = .3, nCharNodes = 0, fixedStyle = c("black", 2))
+    }
+    else if(type == "lab"){
+      semplot <- semPlot::semPaths(fit, what = "est", whatLabels = "names", edge.label.cex = 0.5,
+                                   curvePivot = F, intercepts = T,
+                                   edge.color = "black", filetype = "png", filename = sprintf("output/figures/%s lab", stringr::str_remove_all(as.character(fit@call$model), "[.]")
+                                   ), weighted = F,
+                                   edge.label.position = .3, nCharNodes = 0, fixedStyle = c("black", 2))
+    }
+    return(semplot)
   }
-  else if(type == "std"){
-    semplot <- semPlot::semPaths(fit, what = "std", whatLabels = "std", edge.label.cex = 0.5,
-                                 curvePivot = F, intercepts = F,
-                                 edge.color = "black", filetype = "png", filename = sprintf("output/figures/%s std", stringr::str_remove_all(as.character(fit@call$model), "[.]")
-                                 ), weighted = F,
-                                 edge.label.position = .3, nCharNodes = 0, fixedStyle = c("black", 2))
+
+  if(!is.na(writeout)){
+    if(type == "raw"){
+      semplot <- semPlot::semPaths(fit, what = "est", whatLabels = "est", edge.label.cex = 0.5,
+                                   curvePivot = F, intercepts = F,
+                                   edge.color = "black", filetype = "png", filename = sprintf("%s/%s unstd", writeout, stringr::str_remove_all(as.character(fit@call$model), "[.]")
+                                   ), weighted = F,
+                                   edge.label.position = .3, nCharNodes = 0, fixedStyle = c("black", 2))
+    }
+    else if(type == "std"){
+      semplot <- semPlot::semPaths(fit, what = "std", whatLabels = "std", edge.label.cex = 0.5,
+                                   curvePivot = F, intercepts = F,
+                                   edge.color = "black", filetype = "png", filename = sprintf("%s/%s std", writeout, stringr::str_remove_all(as.character(fit@call$model), "[.]")
+                                   ), weighted = F,
+                                   edge.label.position = .3, nCharNodes = 0, fixedStyle = c("black", 2))
+    }
+    else if(type == "lab"){
+      semplot <- semPlot::semPaths(fit, what = "est", whatLabels = "names", edge.label.cex = 0.5,
+                                   curvePivot = F, intercepts = T,
+                                   edge.color = "black", filetype = "png", filename = sprintf("%s/%s lab", writeout, stringr::str_remove_all(as.character(fit@call$model), "[.]")
+                                   ), weighted = F,
+                                   edge.label.position = .3, nCharNodes = 0, fixedStyle = c("black", 2))
+    }
+    return(semplot)
   }
-  else if(type == "lab"){
-    semplot <- semPlot::semPaths(fit, what = "est", whatLabels = "names", edge.label.cex = 0.5,
-                                 curvePivot = F, intercepts = T,
-                                 edge.color = "black", filetype = "png", filename = sprintf("output/figures/%s lab", stringr::str_remove_all(as.character(fit@call$model), "[.]")
-                                 ), weighted = F,
-                                 edge.label.position = .3, nCharNodes = 0, fixedStyle = c("black", 2))
-  }
-  return(semplot)
+  
 }

--- a/R/outputModel.R
+++ b/R/outputModel.R
@@ -13,8 +13,9 @@
 #' (i.e., both measurement and structural tables)
 #' @param figure logical input of whether figure output is desired. Default is TRUE
 #' @param figtype character input of what type of figure is desired
-#' @param writeout logical (default is FALSE) for whether outputted table and/or figure
-#' should be written to an output subdirectory in current working directory
+#' @param writeout A character string specifying a directory path to where the output file(s) should be written. 
+#' If set to “.”, the output files will be written to the current working directory. 
+#' The default is NA, which will throw an error. 
 #' @return Ignore console (prints unnecessary semPlot::semPaths details). More importantly,
 #' prints word files for the table(s) and/or figure, outputted to the users working directory
 #' @export
@@ -28,7 +29,7 @@
 #' sat.config.mod <- lavaan::cfa(sat.config.script, data = commitmentQ, std.lv = FALSE,
 #' auto.fix.first= FALSE, meanstructure = TRUE)
 #' outputModel(dvnx, model = "cfa", fit = sat.config.mod, table = TRUE,
-#' tabletype = "measurement", figure = "TRUE", figtype = "standardized")
+#' tabletype = "measurement", figure = "TRUE", figtype = "standardized", writeout = tempdir())
 
 #' dvnxy <- scrapeVarCross(dat = commitmentQ, x_order = "spi", x_stem = "sat.g", x_delim1 = ".",
 #' x_delim2="_", distinguish_1="1", distinguish_2="2",
@@ -40,12 +41,24 @@
 #' auto.fix.first= FALSE, meanstructure = TRUE)
 #'
 #' outputModel(dvnxy, model = "apim", fit = apim.indist.mod, table = TRUE,
-#' tabletype = "measurement", figure = "TRUE", figtype = "standardized")
+#' tabletype = "measurement", figure = "TRUE", figtype = "standardized", writeout = tempdir())
 
 outputModel  <-  function(dvn, model = NULL, fit,
                     table = TRUE, tabletype = NULL,
                     figure = TRUE, figtype = NULL,
-                    writeout = FALSE){
+                    writeout = NA){
+  
+  # checking for valid directory path
+  if (is.na(writeout)){
+    stop("Must specify a directory to which the file should be saved. \n Use writeout = '.' to save output file(s) in the current working directory.")
+  }
+  if (!is.character(writeout)){
+    stop("The `writeout` argument must be a character string. \n Use writeout = '.' to save output file(s) in the current working directory.")
+    }
+  if (!dir.exists(writeout)){ 
+    stop("The specified directory does not exist. \n Use writeout = '.' to save output file(s) in the current working directory.")
+    }
+  
   if(model=="cfa"){
     if(table==TRUE & figure == FALSE){
 
@@ -54,53 +67,47 @@ outputModel  <-  function(dvn, model = NULL, fit,
       #Make measurement parameter table
       meas.tab <- makeTable(dvn, fit, model = "cfa", tabletype = "measurement")
 
-      if(isTRUE(writeout)){
-        dirs("output")
-        dirs("output/tables")
-        gt::gtsave(meas.tab, filename = sprintf("./output/tables/%s_Measurement.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")))
-      }
+      gt::gtsave(meas.tab,
+                 filename = sprintf("%s_Measurement.rtf", stringr::str_remove_all(as.character(fit@call$model), "[.]")),
+                 path = writeout)
     }
+    
     else if(table==FALSE & figure == TRUE){
 
-      if(isTRUE(writeout)){
-        dirs("output")
-        dirs("output/figures")
 
+      
         #Make path diagram
         if(figtype == "unstandardized"){
-          semplot <- makeFigure(fit, type = "raw")
+          semplot <- makeFigure(fit, type = "raw", writeout)
         }
         else if(figtype == "standardized"){
-          semplot <- makeFigure(fit, type = "std")
+          semplot <- makeFigure(fit, type = "std", writeout)
         }
         else if(figtype == "labels"){
-          semplot <- makeFigure(fit, type = "raw")
+          semplot <- makeFigure(fit, type = "lab", writeout)
         }
-      }
-
+        
     }
     else if(table==TRUE & figure == TRUE){
 
+      #Make measurement parameter table
       meas.tab <- makeTable(dvn, fit, model = "cfa", tabletype = "measurement")
 
-      if(isTRUE(writeout)){
-        dirs("output")
-        dirs("output/tables")
-        dirs("output/figures")
-
-        gt::gtsave(meas.tab, filename = sprintf("./output/tables/%s_Measurement.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")))
-
+      gt::gtsave(meas.tab,
+                 filename = sprintf("%s_Measurement.rtf", stringr::str_remove_all(as.character(fit@call$model), "[.]")),
+                 path = writeout)
+      
+      #Make measurement parameter table
         if(figtype == "unstandardized"){
-          semplot <- makeFigure(fit, type = "raw")
+          semplot <- makeFigure(fit, type = "raw", writeout)
         }
         else if(figtype == "standardized"){
-          semplot <- makeFigure(fit, type = "std")
+          semplot <- makeFigure(fit, type = "std", writeout)
         }
         else if(figtype == "labels"){
-          semplot <- makeFigure(fit, type = "raw")
+          semplot <- makeFigure(fit, type = "lab", writeout)
         }
-      }
-
+      
     }
   }
   else if(model=="bidyc"){
@@ -109,55 +116,46 @@ outputModel  <-  function(dvn, model = NULL, fit,
       #Make measurement parameter table
       meas.tab <- makeTable(dvn, fit, model = "bidyc", tabletype = "measurement")
 
-      if(isTRUE(writeout)){
-        dirs("output")
-        dirs("output/tables")
-        gt::gtsave(meas.tab, filename = sprintf("./output/tables/%s_Measurement.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")))
-
-      }
-
+      gt::gtsave(meas.tab, filename = sprintf("%s_Measurement.rtf", stringr::str_remove_all(as.character(fit@call$model), "[.]")),
+                   path = writeout)
     }
+    
     else if(table==FALSE & figure == TRUE){
-
-      if(isTRUE(writeout)){
-        dirs("output")
-        dirs("output/figures")
 
         #Make path diagram
         if(figtype == "unstandardized"){
-          semplot <- makeFigure(fit, type = "raw")
+          semplot <- makeFigure(fit, type = "raw", writeout)
         }
         else if(figtype == "standardized"){
-          semplot <- makeFigure(fit, type = "std")
+          semplot <- makeFigure(fit, type = "std", writeout)
         }
         else if(figtype == "labels"){
-          semplot <- makeFigure(fit, type = "lab")
+          semplot <- makeFigure(fit, type = "lab", writeout)
         }
-      }
+      
 
 
     }
     else if(table==TRUE & figure == TRUE){
-
+      
+      #Make measurement parameter table
       meas.tab <- makeTable(dvn, fit, model = "bidyc", tabletype = "measurement")
 
-      if(isTRUE(writeout)){
-        dirs("output")
-        dirs("output/tables")
-        dirs("output/figures")
+      gt::gtsave(meas.tab, filename = sprintf("%s_Measurement.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")),
+                 path = writeout)
 
-        gt::gtsave(meas.tab, filename = sprintf("./output/tables/%s_Measurement.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")))
-
-        if(figtype == "unstandardized"){
-          semplot <- makeFigure(fit, type = "raw")
-        }
-        else if(figtype == "standardized"){
-          semplot <- makeFigure(fit, type = "std")
-        }
-        else if(figtype == "labels"){
-          semplot <- makeFigure(fit, type = "lab")
-        }
+      
+      #Make path diagram
+      if(figtype == "unstandardized"){
+        semplot <- makeFigure(fit, type = "raw", writeout)
       }
+      else if(figtype == "standardized"){
+        semplot <- makeFigure(fit, type = "std", writeout)
+      }
+      else if(figtype == "labels"){
+        semplot <- makeFigure(fit, type = "lab", writeout)
+      }
+      
 
     }
   }
@@ -167,55 +165,47 @@ outputModel  <-  function(dvn, model = NULL, fit,
       if(tabletype== "both"){
         #Make measurement parameter table
         meas.tab <- makeTable(dvn, fit, model = "apim", tabletype = "measurement")
-
+        
         #Extract structural parameters
         struct.tab <- makeTable(dvn, fit, model = "apim", tabletype = "structural")
-
-        if(isTRUE(writeout)){
-          dirs("output")
-          dirs("output/tables")
-          gt::gtsave(meas.tab, filename = sprintf("./output/tables/%s_Measurement.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")))
-          gt::gtsave(struct.tab, filename = sprintf("./output/tables/%s_structural.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")))
-
-        }
+        
+        gt::gtsave(meas.tab, filename = sprintf("%s_Measurement.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")),
+                   path = writeout)
+        gt::gtsave(struct.tab, filename = sprintf("%s_structural.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")),
+                   path = writeout)
       }
+      
       else if(tabletype== "measurement"){
         #Make measurement parameter table
         meas.tab <- makeTable(dvn, fit, model = "apim", tabletype = "measurement")
-        if(isTRUE(writeout)){
-          dirs("output")
-          dirs("output/tables")
-          gt::gtsave(meas.tab, filename = sprintf("./output/tables/%s_Measurement.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")))
-        }
+       
+        gt::gtsave(meas.tab, filename = sprintf("%s_Measurement.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")),
+                   path = writeout)
       }
+      
       else if(tabletype == "structural"){
         #Extract structural parameters
         struct.tab <- makeTable(dvn, fit, model = "apim", tabletype = "structural")
-        if(isTRUE(writeout)){
-          dirs("output")
-          dirs("output/tables")
-          gt::gtsave(struct.tab, filename = sprintf("./output/tables/%s_structural.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")))
-        }
+        
+        gt::gtsave(struct.tab, filename = sprintf("%s_structural.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")),
+                   path = writeout)
       }
     }
+    
     else if(table==FALSE & figure == TRUE){
 
-      if(isTRUE(writeout)){
-        dirs("output")
-        dirs("output/figures")
-        #Make path diagram
-        if(figtype == "unstandardized"){
-          semplot <- makeFigure(fit, type = "raw")
-        }
-        else if(figtype == "standardized"){
-          semplot <- makeFigure(fit, type = "std")
-        }
-        else if(figtype == "labels"){
-          semplot <- makeFigure(fit, type = "lab")
-        }
+      #Make path diagram
+      if(figtype == "unstandardized"){
+        semplot <- makeFigure(fit, type = "raw", writeout)
       }
-
+      else if(figtype == "standardized"){
+        semplot <- makeFigure(fit, type = "std", writeout)
+      }
+      else if(figtype == "labels"){
+        semplot <- makeFigure(fit, type = "lab", writeout)
+      }
     }
+    
     else if(table==TRUE & figure == TRUE){
 
       if(tabletype== "both"){
@@ -225,55 +215,40 @@ outputModel  <-  function(dvn, model = NULL, fit,
         #Extract structural parameters
         struct.tab <- makeTable(dvn, fit, model = "apim", tabletype = "structural")
 
-        if(isTRUE(writeout)){
-          dirs("output")
-          dirs("output/tables")
-          gt::gtsave(meas.tab, filename = sprintf("./output/tables/%s_Measurement.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")))
-          gt::gtsave(struct.tab, filename = sprintf("./output/tables/%s_structural.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")))
-        }
+        gt::gtsave(meas.tab, filename = sprintf("%s_Measurement.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")),
+                   path = writeout)
+        gt::gtsave(struct.tab, filename = sprintf("%s_structural.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")),
+                   path = writeout)
       }
+      
       else if(tabletype== "measurement"){
         #Make measurement parameter table
         meas.tab <- makeTable(dvn, fit, model = "apim", tabletype = "measurement")
 
-        if(isTRUE(writeout)){
-          dirs("output")
-          dirs("output/tables")
-          gt::gtsave(meas.tab, filename = sprintf("./output/tables/%s_Measurement.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")))
-        }
-
+        gt::gtsave(meas.tab, filename = sprintf("%s_Measurement.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")),
+                   path = writeout)
       }
+      
       else if(tabletype== "structural"){
         #Extract structural parameters
         struct.tab <- makeTable(dvn, fit, model = "apim", tabletype = "structural")
 
-        if(isTRUE(writeout)){
-          dirs("output")
-          dirs("output/tables")
-          gt::gtsave(struct.tab, filename = sprintf("./output/tables/%s_structural.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")))
-        }
+        gt::gtsave(struct.tab, filename = sprintf("%s_structural.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")),
+                   path = writeout)
       }
 
       #Make path diagram
 
       if(figtype == "unstandardized"){
-        if(isTRUE(writeout)){
-          dirs("output/figures")
-          semplot <- makeFigure(fit, type = "raw")
-        }
+        semplot <- makeFigure(fit, type = "raw", writeout)
       }
+      
       else if(figtype == "standardized"){
-          if(isTRUE(writeout)){
-            dirs("output/figures")
-            semplot <- makeFigure(fit, type = "std")
-          }
-
+        semplot <- makeFigure(fit, type = "std", writeout)
       }
+      
       else if(figtype == "labels"){
-        if(isTRUE(writeout)){
-          dirs("output/figures")
-          semplot <- makeFigure(fit, type = "lab")
-        }
+        semplot <- makeFigure(fit, type = "lab", writeout)
       }
     }
   }
@@ -286,50 +261,44 @@ outputModel  <-  function(dvn, model = NULL, fit,
         #Extract structural parameters
         struct.tab <- makeTable(dvn, fit, model = "cfm", tabletype = "structural")
 
-        if(isTRUE(writeout)){
-          dirs("output")
-          dirs("output/tables")
-          gt::gtsave(meas.tab, filename = sprintf("./output/tables/%s_Measurement.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")))
-          gt::gtsave(struct.tab, filename = sprintf("./output/tables/%s_structural.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")))
-          }
+        
+        gt::gtsave(meas.tab, filename = sprintf("%s_Measurement.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")),
+                   path = writeout)
+        gt::gtsave(struct.tab, filename = sprintf("%s_structural.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")),
+                   path = writeout)
+        
       }
       else if(tabletype== "measurement"){
         #Make measurement parameter table
         meas.tab <- makeTable(dvn, fit, model = "cfm", tabletype = "measurement")
 
-        if(isTRUE(writeout)){
-          dirs("output")
-          dirs("output/tables")
-          gt::gtsave(meas.tab, filename = sprintf("./output/tables/%s_Measurement.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")))
-        }
+        
+        gt::gtsave(meas.tab, filename = sprintf("%s_Measurement.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")),
+                   path = writeout)
+        
       }
       else if(tabletype == "structural"){
         #Extract structural parameters
         struct.tab <- makeTable(dvn, fit, model = "cfm", tabletype = "structural")
 
-        if(isTRUE(writeout)){
-          dirs("output")
-          dirs("output/tables")
-          gt::gtsave(struct.tab, filename = sprintf("./output/tables/%s_structural.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")))
-        }
+        
+        gt::gtsave(struct.tab, filename = sprintf("%s_structural.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")),
+                   path = writeout)
+        
       }
     }
     else if(table==FALSE & figure == TRUE){
-
-      if(isTRUE(writeout)){
-        dirs("output")
-        dirs("output/figures")
-        #Make path diagram
-        if(figtype == "unstandardized"){
-          semplot <- makeFigure(fit, type = "raw")
-        }
-        else if(figtype == "standardized"){
-          semplot <- makeFigure(fit, type = "std")
-        }
-        else if(figtype == "labels"){
-          semplot <- makeFigure(fit, type = "lab")
-        }
+      #Make path diagram
+      if(figtype == "unstandardized"){
+        semplot <- makeFigure(fit, type = "raw", writeout)
       }
+      else if(figtype == "standardized"){
+        semplot <- makeFigure(fit, type = "std", writeout)
+      }
+      else if(figtype == "labels"){
+        semplot <- makeFigure(fit, type = "lab", writeout)
+      }
+      
     }
     else if(table==TRUE & figure == TRUE){
 
@@ -339,47 +308,40 @@ outputModel  <-  function(dvn, model = NULL, fit,
 
         #Extract structural parameters
         struct.tab <- makeTable(dvn, fit, model = "cfm", tabletype = "structural")
-        if(isTRUE(writeout)){
-          dirs("output")
-          dirs("output/tables")
-          dirs("output/figures")
-          gt::gtsave(meas.tab, filename = sprintf("./output/tables/%s_Measurement.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")))
-          gt::gtsave(struct.tab, filename = sprintf("./output/tables/%s_structural.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")))
-
-        }
+        
+        gt::gtsave(meas.tab, filename = sprintf("%s_Measurement.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")),
+                   path = writeout)
+        gt::gtsave(struct.tab, filename = sprintf("%s_structural.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")),
+                   path = writeout)
+        
+        
       }
       else if(tabletype== "measurement"){
         #Make measurement parameter table
         meas.tab <- makeTable(dvn, fit, model = "cfm", tabletype = "measurement")
 
-        if(isTRUE(writeout)){
-          dirs("output")
-          dirs("output/tables")
-          dirs("output/figures")
-          gt::gtsave(meas.tab, filename = sprintf("./output/tables/%s_Measurement.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")))
-        }
+        gt::gtsave(meas.tab, filename = sprintf("%s_Measurement.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")),
+                   path = writeout)
+        
       }
       else if(tabletype== "structural"){
         #Extract structural parameters
         struct.tab <- makeTable(dvn, fit, model = "cfm", tabletype = "structural")
 
-        if(isTRUE(writeout)){
-          dirs("output")
-          dirs("output/tables")
-          dirs("output/figures")
-          gt::gtsave(struct.tab, filename = sprintf("./output/tables/%s_structural.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")))
-        }
+        gt::gtsave(struct.tab, filename = sprintf("%s_structural.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")),
+                   path = writeout)
+        
       }
 
       #Make path diagram
       if(figtype == "unstandardized"){
-        semplot <- makeFigure(fit, type = "raw")
+        semplot <- makeFigure(fit, type = "raw", writeout)
       }
       else if(figtype == "standardized"){
-        semplot <- makeFigure(fit, type = "std")
+        semplot <- makeFigure(fit, type = "std", writeout)
       }
       else if(figtype == "labels"){
-        semplot <- makeFigure(fit, type = "lab")
+        semplot <- makeFigure(fit, type = "lab", writeout)
       }
     }
   }
@@ -391,51 +353,47 @@ outputModel  <-  function(dvn, model = NULL, fit,
         #Extract structural parameters
         struct.tab <- makeTable(dvn, fit, model = "bidys", tabletype = "structural")
 
-        if(isTRUE(writeout)){
-          dirs("output")
-          dirs("output/tables")
-          gt::gtsave(meas.tab, filename = sprintf("./output/tables/%s_Measurement.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")))
-          gt::gtsave(struct.tab, filename = sprintf("./output/tables/%s_structural.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")))
-        }
+      
+        gt::gtsave(meas.tab, filename = sprintf("%s_Measurement.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")),
+                   path = writeout)
+        gt::gtsave(struct.tab, filename = sprintf("%s_structural.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")),
+                   path = writeout)
+        
 
       }
       else if(tabletype== "measurement"){
         #Make measurement parameter table
         meas.tab <- makeTable(dvn, fit, model = "bidys", tabletype = "measurement")
 
-        if(isTRUE(writeout)){
-          dirs("output")
-          dirs("output/tables")
-          gt::gtsave(meas.tab, filename = sprintf("./output/tables/%s_Measurement.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")))
-        }
+        
+        gt::gtsave(meas.tab, filename = sprintf("%s_Measurement.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")),
+                   path = writeout)
+        
       }
       else if(tabletype == "structural"){
         #Extract structural parameters
         struct.tab <- makeTable(dvn, fit, model = "bidys", tabletype = "structural")
 
-        if(isTRUE(writeout)){
-          dirs("output")
-          dirs("output/tables")
-          gt::gtsave(struct.tab, filename = sprintf("./output/tables/%s_structural.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")))
-        }
+       
+        gt::gtsave(struct.tab, filename = sprintf("%s_structural.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")),
+                   path = writeout)
+        
       }
     }
     else if(table==FALSE & figure == TRUE){
 
-      if(isTRUE(writeout)){
-        dirs("output")
-        dirs("output/figures")
-        #Make path diagram
-        if(figtype == "unstandardized"){
-          semplot <- makeFigure(fit, type = "raw")
-        }
-        else if(figtype == "standardized"){
-          semplot <- makeFigure(fit, type = "std")
-        }
-        else if(figtype == "labels"){
-          semplot <- makeFigure(fit, type = "lab")
-        }
+
+      #Make path diagram
+      if(figtype == "unstandardized"){
+        semplot <- makeFigure(fit, type = "raw", writeout)
       }
+      else if(figtype == "standardized"){
+        semplot <- makeFigure(fit, type = "std", writeout)
+      }
+      else if(figtype == "labels"){
+        semplot <- makeFigure(fit, type = "lab", writeout)
+      }
+      
     }
     else if(table==TRUE & figure == TRUE){
 
@@ -446,46 +404,41 @@ outputModel  <-  function(dvn, model = NULL, fit,
         #Extract structural parameters
         struct.tab <- makeTable(dvn, fit, model = "bidys", tabletype = "structural")
 
-        if(isTRUE(writeout)){
-          dirs("output")
-          dirs("output/tables")
-          dirs("output/figures")
-          gt::gtsave(struct.tab, filename = sprintf("./output/tables/%s_structural.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")))
-          gt::gtsave(meas.tab, filename = sprintf("./output/tables/%s_Measurement.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")))
-        }
+   
+        gt::gtsave(struct.tab, filename = sprintf("%s_structural.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")),
+                   path = writeout)
+        gt::gtsave(meas.tab, filename = sprintf("%s_Measurement.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")),
+                   path = writeout)
+        
       }
       else if(tabletype== "measurement"){
         #Make measurement parameter table
         meas.tab <- makeTable(dvn, fit, model = "bidys", tabletype = "measurement")
 
-        if(isTRUE(writeout)){
-          dirs("output")
-          dirs("output/tables")
-          dirs("output/figures")
-          gt::gtsave(meas.tab, filename = sprintf("./output/tables/%s_Measurement.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")))
-        }
+  
+        gt::gtsave(meas.tab, filename = sprintf("%s_Measurement.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")),
+                   path = writeout)
+        
       }
       else if(tabletype== "structural"){
         #Extract structural parameters
         struct.tab <- makeTable(dvn, fit, model = "bidys", tabletype = "structural")
 
-        if(isTRUE(writeout)){
-          dirs("output")
-          dirs("output/tables")
-          dirs("output/figures")
-          gt::gtsave(struct.tab, filename = sprintf("./output/tables/%s_structural.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")))
-        }
+
+        gt::gtsave(struct.tab, filename = sprintf("%s_structural.rtf",stringr::str_remove_all(as.character(fit@call$model), "[.]")),
+                   path = writeout)
+        
       }
 
       #Make path diagram
       if(figtype == "unstandardized"){
-        semplot <- makeFigure(fit, type = "raw")
+        semplot <- makeFigure(fit, type = "raw", writeout)
       }
       else if(figtype == "standardized"){
-        semplot <- makeFigure(fit, type = "std")
+        semplot <- makeFigure(fit, type = "std", writeout)
       }
       else if(figtype == "labels"){
-        semplot <- makeFigure(fit, type = "lab")
+        semplot <- makeFigure(fit, type = "lab", writeout)
       }
     }
   }

--- a/R/scriptAPIM.R
+++ b/R/scriptAPIM.R
@@ -37,7 +37,7 @@
 #' calculated to characterize the dyadic pattern in the APIM. Defaults FALSE, and requires at least
 #' a loading-invariant model to be specified, otherwise a warning is returned.
 #' @param writescript input logical (default FALSE) for whether lavaan script should
-#' be concatenated and written to current working directory (in subdirectory "scripts")
+#' be concatenated and written to current working directory
 #' @return character object of lavaan script that can be passed immediately to
 #' lavaan functions. Users will receive message if structural comparisons are specified
 #' when the recommended level of invariance is not also specified. If user supplies dvn
@@ -382,8 +382,8 @@ scriptAPIM <- function(dvn, scaleset = "FF",
 
   #Write script to file if requested
   if(isTRUE(writescript)){
-    dirs("scripts")
-    cat(script,"\n", file = sprintf("./scripts/%s_%s_apim_x_%s_y_%s_xy_%s.txt",
+    
+    cat(script,"\n", file = sprintf("./%s_%s_apim_x_%s_y_%s_xy_%s.txt",
                                     lvxname, lvyname,
                                     paste0(paste0(constr_dy_x_meas, collapse = "_"),
                                            "_",

--- a/R/scriptBiDy.R
+++ b/R/scriptBiDy.R
@@ -34,7 +34,7 @@
 #' are constrained to equivalency between partners. Users should rely upon constr_dy_xy_struct for making
 #' constraints to the structural portion of the model for associative relationship between latent x and y.
 #' @param writescript input logical (default FALSE) for whether lavaan script should
-#' be concatenated and written to current working directory (in subdirectory "scripts")
+#' be concatenated and written to current working directory
 #' @importFrom rlang .data
 #' @return character object of lavaan script that can be passed immediately to
 #' lavaan functions
@@ -185,8 +185,8 @@ scriptBiDy <- function(dvn, type = "CFA", lvxname, lvyname,
 
     #Write script to file if requested
     if(isTRUE(writescript)){
-      dirs("scripts")
-      cat(script,"\n", file = sprintf("./scripts/%s_bidyc_meas_%s_struct_%s.txt",lvxname, paste0(constr_dy_x_meas, collapse = "_"), paste0(constr_dy_x_struct, collapse = "_")))
+      
+      cat(script,"\n", file = sprintf("./%s_bidyc_meas_%s_struct_%s.txt",lvxname, paste0(constr_dy_x_meas, collapse = "_"), paste0(constr_dy_x_struct, collapse = "_")))
     }
 
     return(script)
@@ -255,22 +255,22 @@ scriptBiDy <- function(dvn, type = "CFA", lvxname, lvyname,
 
     #loadings for Y
     if(any(constr_dy_y_meas == "loadings")){
-      yloadsg <- loads(dvn, lvar = "Y", lvxname, partner = "g", type = "equated")
-      yloads1 <- loads(dvn, lvar = "Y",lvxname, partner="1", type = "equated")
-      yloads2 <- loads(dvn, lvar = "Y",lvxname, partner="2", type = "equated")
+      yloadsg <- loads(dvn, lvar = "Y", lvyname, partner = "g", type = "equated")
+      yloads1 <- loads(dvn, lvar = "Y",lvyname, partner="1", type = "equated")
+      yloads2 <- loads(dvn, lvar = "Y",lvyname, partner="2", type = "equated")
     }
     else if(any(constr_dy_y_meas == "loading_source")){
-      yloadsg <- loads(dvn, lvar = "Y", lvxname, partner = "g", type = "equated_source")
-      yloads1 <- loads(dvn, lvar = "Y",lvxname, partner="1", type = "equated_source")
-      yloads2 <- loads(dvn, lvar = "Y",lvxname, partner="2", type = "equated_source")
+      yloadsg <- loads(dvn, lvar = "Y", lvyname, partner = "g", type = "equated_source")
+      yloads1 <- loads(dvn, lvar = "Y",lvyname, partner="1", type = "equated_source")
+      yloads2 <- loads(dvn, lvar = "Y",lvyname, partner="2", type = "equated_source")
     }else if(any(constr_dy_y_meas == "loading_mutual")){
-      yloadsg <- loads(dvn, lvar = "Y", lvxname, partner = "g", type = "equated")
-      yloads1 <- loads(dvn, lvar = "Y",lvxname, partner="1", type = "free")
-      yloads2 <- loads(dvn, lvar = "Y",lvxname, partner="2", type = "free")
+      yloadsg <- loads(dvn, lvar = "Y", lvyname, partner = "g", type = "equated")
+      yloads1 <- loads(dvn, lvar = "Y",lvyname, partner="1", type = "free")
+      yloads2 <- loads(dvn, lvar = "Y",lvyname, partner="2", type = "free")
     }else{
-      yloadsg <- loads(dvn, lvar = "Y", lvxname, partner = "g", type = "free")
-      yloads1 <- loads(dvn, lvar = "Y",lvxname, partner="1", type = "free")
-      yloads2 <- loads(dvn, lvar = "Y",lvxname, partner="2", type = "free")
+      yloadsg <- loads(dvn, lvar = "Y", lvyname, partner = "g", type = "free")
+      yloads1 <- loads(dvn, lvar = "Y",lvyname, partner="1", type = "free")
+      yloads2 <- loads(dvn, lvar = "Y",lvyname, partner="2", type = "free")
     }
 
     #intercepts for X
@@ -430,8 +430,8 @@ scriptBiDy <- function(dvn, type = "CFA", lvxname, lvyname,
 
     #Write script to file if requested
     if(isTRUE(writescript)){
-      dirs("scripts")
-      cat(script,"\n", file = sprintf("./scripts/%s_%s_cfm_x_%s_y_%s_xy_%s.txt",
+      
+      cat(script,"\n", file = sprintf("./%s_%s_cfm_x_%s_y_%s_xy_%s.txt",
                                       lvxname, lvyname,
                                       paste0(paste0(constr_dy_x_meas, collapse = "_"),
                                              "_",

--- a/R/scriptCFA.R
+++ b/R/scriptCFA.R
@@ -33,7 +33,7 @@
 #' modeled ("configural", "loading", "intercept", "residual", or "indist"). Users should rely upon constr_dy_meas and
 #' constr_dy_struct instead, for making constraints to the measurement and/or structural portions of the model.
 #' @param writescript input logical (default FALSE) for whether lavaan script should
-#' be concatenated and written to current working directory (in subdirectory "scripts")
+#' be concatenated and written to current working directory
 #' @return character object of lavaan script that can be passed immediately to
 #' lavaan functions
 #' @seealso \code{\link{scrapeVarCross}} which this function relies on
@@ -210,8 +210,8 @@ scriptCFA <- function(dvn, scaleset = "FF", lvname = "X",
 
   #Write script to file if requested
   if(isTRUE(writescript)){
-    dirs("scripts")
-    cat(script,"\n", file = sprintf("./scripts/%s_dcfa_meas_%s_struct_%s.txt",lvname, paste0(constr_dy_meas, collapse = "_"), paste0(constr_dy_struct, collapse = "_")))
+    
+    cat(script,"\n", file = sprintf("./%s_dcfa_meas_%s_struct_%s.txt",lvname, paste0(constr_dy_meas, collapse = "_"), paste0(constr_dy_struct, collapse = "_")))
   }
 
   return(script)

--- a/R/scriptCFM.R
+++ b/R/scriptCFM.R
@@ -32,7 +32,7 @@
 #' modeled. Users should rely upon constr_dy_x_meas/constr_dy_y_meas and
 #' constr_dy_x_struct/constr_dy_y_struct instead, for making constraints to the measurement and/or structural portions of the model for latent x and y.
 #' @param writescript input logical (default FALSE) for whether lavaan script should
-#' be concatenated and written to current working directory (in subdirectory "scripts")
+#' be concatenated and written to current working directory
 #' @return character object of lavaan script that can be passed immediately to
 #' lavaan functions. Users will receive message if structural comparisons are specified
 #' when the recommended level of invariance is not also specified. If user supplies dvn
@@ -362,8 +362,8 @@ scriptCFM  <- function(dvn, scaleset = "FF",
 
   #Write script to file if requested
   if(isTRUE(writescript)){
-    dirs("scripts")
-    cat(script,"\n", file = sprintf("./scripts/%s_%s_cfm_x_%s_y_%s_xy_%s.txt",
+    
+    cat(script,"\n", file = sprintf("./%s_%s_cfm_x_%s_y_%s_xy_%s.txt",
                                     lvxname, lvyname,
                                     paste0(paste0(constr_dy_x_meas, collapse = "_"),
                                            "_",

--- a/R/scriptINULL.R
+++ b/R/scriptINULL.R
@@ -8,7 +8,7 @@
 #' @param lvxname input character to (arbitrarily) name X LV in lavaan syntax
 #' @param lvyname (optional) input character to (arbitrarily) name Y LV in lavaan syntax
 #' @param writescript input logical (default FALSE) for whether lavaan script should
-#' be concatenated and written to current working directory (in subdirectory "scripts")
+#' be concatenated and written to current working directory
 #' @return character object of lavaan script that can be passed immediately to
 #' lavaan functions
 #' @seealso \code{\link{scrapeVarCross}} which this function relies on
@@ -96,8 +96,8 @@ scriptINULL = function(dvn, lvxname = "X", lvyname = NULL, writescript =FALSE){
                            covars)
 
     if(isTRUE(writescript)){
-      dirs("scripts")
-      cat(INULL.script,"\n", file = sprintf("./scripts/%s_INULL.txt",lvxname))
+      
+      cat(INULL.script,"\n", file = sprintf("./%s_INULL.txt",lvxname))
     }
 
   }else if(length(dvn) == 9){
@@ -107,8 +107,8 @@ scriptINULL = function(dvn, lvxname = "X", lvyname = NULL, writescript =FALSE){
                            covars)
 
     if(isTRUE(writescript)){
-      dirs("scripts")
-      cat(INULL.script,"\n", file = sprintf("./scripts/%s_%s_INULL.txt",lvxname, lvyname))
+      
+      cat(INULL.script,"\n", file = sprintf("./%s_%s_INULL.txt",lvxname, lvyname))
     }
   }
 

--- a/R/scriptISAT.R
+++ b/R/scriptISAT.R
@@ -8,7 +8,7 @@
 #' @param lvxname input character to (arbitrarily) name X LV in lavaan syntax
 #' @param lvyname (optional) input character to (arbitrarily) name X LV in lavaan syntax
 #' @param writescript input logical (default FALSE) for whether lavaan script should
-#' be concatenated and written to current working directory (in subdirectory "scripts")
+#' be concatenated and written to current working directory
 #' @return character object of lavaan script that can be passed immediately to
 #' lavaan functions
 #' @seealso \code{\link{scrapeVarCross}} which this function relies on
@@ -313,8 +313,8 @@ scriptISAT = function(dvn, lvxname = "X", lvyname = NULL, writescript = FALSE){
                           xfree.cor)
 
     if(isTRUE(writescript)){
-      dirs("scripts")
-      cat(ISAT.script,"\n", file = sprintf("./scripts/%s_ISAT.txt",lvxname))
+      
+      cat(ISAT.script,"\n", file = sprintf("./%s_ISAT.txt",lvxname))
     }
 
   }else if(length(dvn) == 9){
@@ -326,8 +326,8 @@ scriptISAT = function(dvn, lvxname = "X", lvyname = NULL, writescript = FALSE){
                           xfree.cor, yfree.cor)
 
     if(isTRUE(writescript)){
-      dirs("scripts")
-      cat(ISAT.script,"\n", file = sprintf("./scripts/%s_%s_ISAT.txt",lvxname, lvyname))
+      
+      cat(ISAT.script,"\n", file = sprintf("./%s_%s_ISAT.txt",lvxname, lvyname))
       }
 
   }

--- a/R/scriptMIM.R
+++ b/R/scriptMIM.R
@@ -37,7 +37,7 @@
 #' calculated to characterize the dyadic pattern in the APIM. Defaults FALSE, and requires at least
 #' a loading-invariant model to be specified, otherwise a warning is returned.
 #' @param writescript input logical (default FALSE) for whether lavaan script should
-#' be concatenated and written to current working directory (in subdirectory "scripts")
+#' be concatenated and written to current working directory
 #' @return character object of lavaan script that can be passed immediately to
 #' lavaan functions. Users will receive message if structural comparisons are specified
 #' when the recommended level of invariance is not also specified. If user supplies dvn
@@ -384,8 +384,8 @@ scriptMIM <- function(dvn, scaleset = "FF",
 
   #Write script to file if requested
   if(isTRUE(writescript)){
-    dirs("scripts")
-    cat(script,"\n", file = sprintf("./scripts/%s_%s_apim_x_%s_y_%s_xy_%s.txt",
+    
+    cat(script,"\n", file = sprintf("./%s_%s_apim_x_%s_y_%s_xy_%s.txt",
                                     lvxname, lvyname,
                                     paste0(paste0(constr_dy_x_meas, collapse = "_"),
                                            "_",

--- a/R/scriptObsAPIM.R
+++ b/R/scriptObsAPIM.R
@@ -9,7 +9,7 @@
 #' @param k input logical for whether Kenny & Ledermann's (2010) k parameter should be
 #' calculated to characterize the dyadic pattern in the APIM. Default to FALSE
 #' @param writescript input logical (default FALSE) for whether lavaan script should
-#' be concatenated and written to current working directory (in subdirectory "scripts")
+#' be concatenated and written to current working directory
 #'
 #' @return character object of lavaan script that can be passed immediately to
 #' lavaan functions.
@@ -99,7 +99,7 @@ scriptObsAPIM <- function(X1 = NULL, Y1 = NULL,
   }
 
   if(isTRUE(writescript)){
-    cat(apimScript,"\n", file = sprintf("./scripts/observed_apim_equate_%s_k_%s.txt",equate, k))
+    cat(apimScript,"\n", file = sprintf("./observed_apim_equate_%s_k_%s.txt",equate, k))
   }
 
   return(apimScript)

--- a/man/outputModel.Rd
+++ b/man/outputModel.Rd
@@ -12,7 +12,7 @@ outputModel(
   tabletype = NULL,
   figure = TRUE,
   figtype = NULL,
-  writeout = FALSE
+  writeout = NA
 )
 }
 \arguments{
@@ -33,8 +33,9 @@ options are "measurement" (i.e,, loadings, intercepts,),
 
 \item{figtype}{character input of what type of figure is desired}
 
-\item{writeout}{logical (default is FALSE) for whether outputted table and/or figure
-should be written to an output subdirectory in current working directory}
+\item{writeout}{A character string specifying a directory path to where the output file(s) should be written.
+If set to “.”, the output files will be written to the current working directory.
+The default is NA, which will throw an error.}
 }
 \value{
 Ignore console (prints unnecessary semPlot::semPaths details). More importantly,
@@ -54,7 +55,7 @@ constr_dy_struct = "none")
 sat.config.mod <- lavaan::cfa(sat.config.script, data = commitmentQ, std.lv = FALSE,
 auto.fix.first= FALSE, meanstructure = TRUE)
 outputModel(dvnx, model = "cfa", fit = sat.config.mod, table = TRUE,
-tabletype = "measurement", figure = "TRUE", figtype = "standardized")
+tabletype = "measurement", figure = "TRUE", figtype = "standardized", writeout = tempdir())
 dvnxy <- scrapeVarCross(dat = commitmentQ, x_order = "spi", x_stem = "sat.g", x_delim1 = ".",
 x_delim2="_", distinguish_1="1", distinguish_2="2",
 y_order="spi", y_stem="com", y_delim1 = ".", y_delim2="_")
@@ -65,5 +66,5 @@ apim.indist.mod <- lavaan::cfa(apim.indist.script, data = commitmentQ, std.lv = 
 auto.fix.first= FALSE, meanstructure = TRUE)
 
 outputModel(dvnxy, model = "apim", fit = apim.indist.mod, table = TRUE,
-tabletype = "measurement", figure = "TRUE", figtype = "standardized")
+tabletype = "measurement", figure = "TRUE", figtype = "standardized", writeout = tempdir())
 }

--- a/man/scriptAPIM.Rd
+++ b/man/scriptAPIM.Rd
@@ -65,7 +65,7 @@ calculated to characterize the dyadic pattern in the APIM. Defaults FALSE, and r
 a loading-invariant model to be specified, otherwise a warning is returned.}
 
 \item{writescript}{input logical (default FALSE) for whether lavaan script should
-be concatenated and written to current working directory (in subdirectory "scripts")}
+be concatenated and written to current working directory}
 }
 \value{
 character object of lavaan script that can be passed immediately to

--- a/man/scriptBiDy.Rd
+++ b/man/scriptBiDy.Rd
@@ -61,7 +61,7 @@ are constrained to equivalency between partners. Users should rely upon constr_d
 constraints to the structural portion of the model for associative relationship between latent x and y.}
 
 \item{writescript}{input logical (default FALSE) for whether lavaan script should
-be concatenated and written to current working directory (in subdirectory "scripts")}
+be concatenated and written to current working directory}
 }
 \value{
 character object of lavaan script that can be passed immediately to

--- a/man/scriptCFA.Rd
+++ b/man/scriptCFA.Rd
@@ -37,7 +37,7 @@ modeled ("configural", "loading", "intercept", "residual", or "indist"). Users s
 constr_dy_struct instead, for making constraints to the measurement and/or structural portions of the model.}
 
 \item{writescript}{input logical (default FALSE) for whether lavaan script should
-be concatenated and written to current working directory (in subdirectory "scripts")}
+be concatenated and written to current working directory}
 }
 \value{
 character object of lavaan script that can be passed immediately to

--- a/man/scriptCFM.Rd
+++ b/man/scriptCFM.Rd
@@ -56,7 +56,7 @@ modeled. Users should rely upon constr_dy_x_meas/constr_dy_y_meas and
 constr_dy_x_struct/constr_dy_y_struct instead, for making constraints to the measurement and/or structural portions of the model for latent x and y.}
 
 \item{writescript}{input logical (default FALSE) for whether lavaan script should
-be concatenated and written to current working directory (in subdirectory "scripts")}
+be concatenated and written to current working directory}
 }
 \value{
 character object of lavaan script that can be passed immediately to

--- a/man/scriptINULL.Rd
+++ b/man/scriptINULL.Rd
@@ -15,7 +15,7 @@ scriptINULL(dvn, lvxname = "X", lvyname = NULL, writescript = FALSE)
 \item{lvyname}{(optional) input character to (arbitrarily) name Y LV in lavaan syntax}
 
 \item{writescript}{input logical (default FALSE) for whether lavaan script should
-be concatenated and written to current working directory (in subdirectory "scripts")}
+be concatenated and written to current working directory}
 }
 \value{
 character object of lavaan script that can be passed immediately to

--- a/man/scriptISAT.Rd
+++ b/man/scriptISAT.Rd
@@ -15,7 +15,7 @@ scriptISAT(dvn, lvxname = "X", lvyname = NULL, writescript = FALSE)
 \item{lvyname}{(optional) input character to (arbitrarily) name X LV in lavaan syntax}
 
 \item{writescript}{input logical (default FALSE) for whether lavaan script should
-be concatenated and written to current working directory (in subdirectory "scripts")}
+be concatenated and written to current working directory}
 }
 \value{
 character object of lavaan script that can be passed immediately to

--- a/man/scriptMIM.Rd
+++ b/man/scriptMIM.Rd
@@ -65,7 +65,7 @@ calculated to characterize the dyadic pattern in the APIM. Defaults FALSE, and r
 a loading-invariant model to be specified, otherwise a warning is returned.}
 
 \item{writescript}{input logical (default FALSE) for whether lavaan script should
-be concatenated and written to current working directory (in subdirectory "scripts")}
+be concatenated and written to current working directory}
 }
 \value{
 character object of lavaan script that can be passed immediately to

--- a/man/scriptObsAPIM.Rd
+++ b/man/scriptObsAPIM.Rd
@@ -30,7 +30,7 @@ scriptObsAPIM(
 calculated to characterize the dyadic pattern in the APIM. Default to FALSE}
 
 \item{writescript}{input logical (default FALSE) for whether lavaan script should
-be concatenated and written to current working directory (in subdirectory "scripts")}
+be concatenated and written to current working directory}
 }
 \value{
 character object of lavaan script that can be passed immediately to


### PR DESCRIPTION
Addresses Issue #111 

Scripters

- Removed `dirs()` step
- Updated `cat()` to write `lavaan` scripts directly to the current working directory rather than the subdirectory created by `dirs()`.
- Updated documentation

outputModel.R

- Removed `dirs()` step
- Updated the `writeout` argument to accept character strings specifying where to write the output files.
- Updated `gt::gtsave()` to write tables directly to the current working directory
- Updated the `dySEM:::makeFigure()` helper function to accept the new `writeout` argument
- Updated documentation
- Updated `@examples` to write to `tempdir()`

I also saw potential typos in scriptBiDy.R (see lines 258 to 273) and outputModel.R (see lines 77 and 100).
