### PR TITLE
Fix: Created `writeTo` and `fileName` arguments for scripters and `outputModel()`

### DIFF
--- a/R/outHelpers.R
+++ b/R/outHelpers.R
@@ -8,6 +8,11 @@
 #' @param model type of fitted dyadic model (i.e., "apim", "bidyc", "bidys","cfa", "cfm", "mim")
 #' @param tabletype kind of parameter estimates requested (i.e. from "measurement" or "structural" model)
 #' @param type input character for sempaths to indicate whether parameters "free" or "equated" in estimation
+#' @param writeTo A character string specifying a directory path to where the file(s) should be saved.
+#' The default is a path to a temporary directory created by tempdir().
+#' @param fileName A character string specifying a desired base name for the output file(s). 
+#' If a `fileName` not provided (i.e., "fileName = NULL"), then defaults will be used 
+#' The specified name will be automatically appended with the appropriate file extension (i.e., .png for figures). 
 #' @family helpers
 #' @noRd
 
@@ -166,27 +171,56 @@ makeTable <- function(dvn, fit, model, tabletype){
 #' @rdname outHelpers
 #' @noRd
 
-makeFigure <- function(fit, type){
-  if(type == "raw"){
-    semplot <- semPlot::semPaths(fit, what = "est", whatLabels = "est", edge.label.cex = 0.5,
-                                 curvePivot = F, intercepts = F,
-                                 edge.color = "black", filetype = "png", filename = sprintf("output/figures/%s unstd", stringr::str_remove_all(as.character(fit@call$model), "[.]")
-                                 ), weighted = F,
-                                 edge.label.position = .3, nCharNodes = 0, fixedStyle = c("black", 2))
+makeFigure <- function(fit, type, writeTo, fileName){
+  #user provides fileName
+  if(!is.null(fileName)){
+    
+    if(type == "raw"){
+      semplot <- semPlot::semPaths(fit, what = "est", whatLabels = "est", edge.label.cex = 0.5,
+                                   curvePivot = F, intercepts = F,
+                                   edge.color = "black", filetype = "png", filename = sprintf("%s/%s unstd", writeTo, fileName
+                                   ), weighted = F,
+                                   edge.label.position = .3, nCharNodes = 0, fixedStyle = c("black", 2))
+    }
+    else if(type == "std"){
+      semplot <- semPlot::semPaths(fit, what = "std", whatLabels = "std", edge.label.cex = 0.5,
+                                   curvePivot = F, intercepts = F,
+                                   edge.color = "black", filetype = "png", filename = sprintf("%s/%s std", writeTo, fileName
+                                   ), weighted = F,
+                                   edge.label.position = .3, nCharNodes = 0, fixedStyle = c("black", 2))
+    }
+    else if(type == "lab"){
+      semplot <- semPlot::semPaths(fit, what = "est", whatLabels = "names", edge.label.cex = 0.5,
+                                   curvePivot = F, intercepts = T,
+                                   edge.color = "black", filetype = "png", filename = sprintf("%s/%s lab", writeTo, fileName
+                                   ), weighted = F,
+                                   edge.label.position = .3, nCharNodes = 0, fixedStyle = c("black", 2))
+    }
   }
-  else if(type == "std"){
-    semplot <- semPlot::semPaths(fit, what = "std", whatLabels = "std", edge.label.cex = 0.5,
-                                 curvePivot = F, intercepts = F,
-                                 edge.color = "black", filetype = "png", filename = sprintf("output/figures/%s std", stringr::str_remove_all(as.character(fit@call$model), "[.]")
-                                 ), weighted = F,
-                                 edge.label.position = .3, nCharNodes = 0, fixedStyle = c("black", 2))
+  
+  #default
+  if(is.null(fileName)){
+    
+    if(type == "raw"){
+      semplot <- semPlot::semPaths(fit, what = "est", whatLabels = "est", edge.label.cex = 0.5,
+                                   curvePivot = F, intercepts = F,
+                                   edge.color = "black", filetype = "png", filename = sprintf("%s/dySEM_figure unstd", writeTo),
+                                   weighted = F,
+                                   edge.label.position = .3, nCharNodes = 0, fixedStyle = c("black", 2))
+    }
+    else if(type == "std"){
+      semplot <- semPlot::semPaths(fit, what = "std", whatLabels = "std", edge.label.cex = 0.5,
+                                   curvePivot = F, intercepts = F,
+                                   edge.color = "black", filetype = "png", filename = sprintf("%s/dySEM_figure std", writeTo), weighted = F,
+                                   edge.label.position = .3, nCharNodes = 0, fixedStyle = c("black", 2))
+    }
+    else if(type == "lab"){
+      semplot <- semPlot::semPaths(fit, what = "est", whatLabels = "names", edge.label.cex = 0.5,
+                                   curvePivot = F, intercepts = T,
+                                   edge.color = "black", filetype = "png", filename = sprintf("%s/dySEM_figure lab", writeTo), weighted = F,
+                                   edge.label.position = .3, nCharNodes = 0, fixedStyle = c("black", 2))
+    }
   }
-  else if(type == "lab"){
-    semplot <- semPlot::semPaths(fit, what = "est", whatLabels = "names", edge.label.cex = 0.5,
-                                 curvePivot = F, intercepts = T,
-                                 edge.color = "black", filetype = "png", filename = sprintf("output/figures/%s lab", stringr::str_remove_all(as.character(fit@call$model), "[.]")
-                                 ), weighted = F,
-                                 edge.label.position = .3, nCharNodes = 0, fixedStyle = c("black", 2))
-  }
+  
   return(semplot)
 }

--- a/R/scriptAPIM.R
+++ b/R/scriptAPIM.R
@@ -36,8 +36,12 @@
 #' @param est_k input logical for whether Kenny & Ledermann's (2010) k parameter should be
 #' calculated to characterize the dyadic pattern in the APIM. Defaults FALSE, and requires at least
 #' a loading-invariant model to be specified, otherwise a warning is returned.
-#' @param writescript input logical (default FALSE) for whether lavaan script should
-#' be concatenated and written to current working directory (in subdirectory "scripts")
+#' @param writeTo A character string specifying a directory path to where a .txt file of the resulting lavaan script should be written.
+#' If set to “.”, the .txt file will be written to the current working directory.
+#' The default is a path to a temporary directory created by tempdir().
+#' @param fileName A character string specifying a desired base name for the .txt output file.
+#' The default is "latAPIM_script". The specified name will be automatically appended with the .txt file extension.
+#' If a file with the same name already exists in the user's chosen directory, it will be overwritten.
 #' @return character object of lavaan script that can be passed immediately to
 #' lavaan functions. Users will receive message if structural comparisons are specified
 #' when the recommended level of invariance is not also specified. If user supplies dvn
@@ -49,7 +53,9 @@
 #' dvn <- scrapeVarCross(dat = commitmentQ, x_order = "spi", x_stem = "sat.g", x_delim1 = ".",
 #' x_delim2="_", distinguish_1="1", distinguish_2="2",
 #' y_order="spi", y_stem="com", y_delim1 = ".", y_delim2="_")
-#' apim.script.indist <-  scriptAPIM(dvn, lvxname = "Sat", lvyname = "Com", est_k = TRUE)
+#' apim.script.indist <-  scriptAPIM(dvn, lvxname = "Sat", lvyname = "Com", est_k = TRUE,
+#' writeTo = tempdir(),
+#' fileName = "latAPIM_indist")
 
 scriptAPIM <- function(dvn, scaleset = "FF",
                        lvxname, lvyname,
@@ -59,7 +65,8 @@ scriptAPIM <- function(dvn, scaleset = "FF",
                        constr_dy_y_struct = c("variances", "means"),
                        constr_dy_xy_struct = c("actors", "partners"),
                        model = lifecycle::deprecated(), equate = lifecycle::deprecated(), est_k = FALSE,
-                       writescript = FALSE){
+                       writeTo = tempdir(),
+                       fileName = "latAPIM_script"){
 
 
   #stop if model is provided
@@ -381,20 +388,22 @@ scriptAPIM <- function(dvn, scaleset = "FF",
   }
 
   #Write script to file if requested
-  if(isTRUE(writescript)){
-    dirs("scripts")
-    cat(script,"\n", file = sprintf("./scripts/%s_%s_apim_x_%s_y_%s_xy_%s.txt",
-                                    lvxname, lvyname,
-                                    paste0(paste0(constr_dy_x_meas, collapse = "_"),
-                                           "_",
-                                           paste0(constr_dy_x_struct, collapse = "_"),
-                                           collapse = "_"),
-                                    paste0(paste0(constr_dy_y_meas, collapse = "_"),
-                                           "_",
-                                           paste0(constr_dy_y_struct, collapse = "_"),
-                                           collapse = "_"),
-                                    paste0(constr_dy_xy_struct, collapse = "_")))
+  
+  # checking for valid directory path and fileName
+  if (!is.character(writeTo)){
+    stop("The `writeout` argument must be a character string. \n Use writeTo = '.' to save script in the current working directory, for example.")
   }
-
+  if (!dir.exists(writeTo)){ 
+    stop("The specified directory does not exist. \n Use writeTo = '.' to save script in the current working directory, for example.")
+  }
+  if (!is.character(fileName)){
+    stop("The `fileName` argument must be a character string.")
+  }
+  
+  cat(script, "\n", 
+      file = sprintf("%s/%s.txt",
+                     writeTo, 
+                     fileName))
+  
     return(script)
   }

--- a/R/scriptCFA.R
+++ b/R/scriptCFA.R
@@ -32,8 +32,12 @@
 #' @param model Depreceated input character used to specify which level of invariance is
 #' modeled ("configural", "loading", "intercept", "residual", or "indist"). Users should rely upon constr_dy_meas and
 #' constr_dy_struct instead, for making constraints to the measurement and/or structural portions of the model.
-#' @param writescript input logical (default FALSE) for whether lavaan script should
-#' be concatenated and written to current working directory (in subdirectory "scripts")
+#' @param writeTo A character string specifying a directory path to where a .txt file of the resulting lavaan script should be written.
+#' If set to “.”, the .txt file will be written to the current working directory.
+#' The default is a path to a temporary directory created by tempdir().
+#' @param fileName A character string specifying a desired base name for the .txt output file.
+#' The default is "dCFA_script". The specified name will be automatically appended with the .txt file extension.
+#' If a file with the same name already exists in the user's chosen directory, it will be overwritten.
 #' @return character object of lavaan script that can be passed immediately to
 #' lavaan functions
 #' @seealso \code{\link{scrapeVarCross}} which this function relies on
@@ -51,25 +55,34 @@
 #'
 #' sat.resids.script <- scriptCFA(dvn, lvname = "Sat",
 #' constr_dy_meas = c("loadings", "intercepts", "residuals"),
-#' constr_dy_struct = "none")
+#' constr_dy_struct = "none",
+#' writeTo = tempdir(),
+#' fileName = "dCFA_residual")
 #'
 #' sat.ints.script <- scriptCFA(dvn, lvname = "Sat",
 #' constr_dy_meas = c("loadings", "intercepts"),
-#' constr_dy_struct = "none")
+#' constr_dy_struct = "none",
+#' writeTo = tempdir(),
+#' fileName = "dCFA_intercept")
 #'
 #' sat.loads.script <- scriptCFA(dvn, lvname = "Sat",
 #' constr_dy_meas = c("loadings"),
-#' constr_dy_struct = "none")
+#' constr_dy_struct = "none",
+#' writeTo = tempdir(),
+#' fileName = "dCFA_loading")
 #'
 #' sat.config.script <- scriptCFA(dvn, lvname = "Sat",
 #' constr_dy_meas = "none",
-#' constr_dy_struct = "none")
+#' constr_dy_struct = "none",
+#' writeTo = tempdir(),
+#' fileName = "dCFA_configural")
 
 scriptCFA <- function(dvn, scaleset = "FF", lvname = "X",
                       constr_dy_meas = c("loadings", "intercepts", "residuals"),
                       constr_dy_struct = c("variances", "means"),
                       model = lifecycle::deprecated(),
-                      writescript = FALSE){
+                      writeTo = tempdir(),
+                      fileName = "dCFA_script"){
 
   if (lifecycle::is_present(model)) {
     lifecycle::deprecate_stop("1.0.0", "scriptCFA(model)", "scriptCFA(constr_dy_meas)")
@@ -209,11 +222,23 @@ scriptCFA <- function(dvn, scaleset = "FF", lvname = "X",
                     xmean1, xmean2)
 
   #Write script to file if requested
-  if(isTRUE(writescript)){
-    dirs("scripts")
-    cat(script,"\n", file = sprintf("./scripts/%s_dcfa_meas_%s_struct_%s.txt",lvname, paste0(constr_dy_meas, collapse = "_"), paste0(constr_dy_struct, collapse = "_")))
+  
+  # checking for valid directory path and fileName
+  if (!is.character(writeTo)){
+    stop("The `writeout` argument must be a character string. \n Use writeTo = '.' to save script in the current working directory, for example.")
   }
-
+  if (!dir.exists(writeTo)){ 
+    stop("The specified directory does not exist. \n Use writeTo = '.' to save script in the current working directory, for example.")
+  }
+  if (!is.character(fileName)){
+    stop("The `fileName` argument must be a character string.")
+  }
+  
+  cat(script, "\n", 
+      file = sprintf("%s/%s.txt",
+                     writeTo, 
+                     fileName))
+  
   return(script)
 }
 

--- a/R/scriptCFM.R
+++ b/R/scriptCFM.R
@@ -31,8 +31,12 @@
 #' @param model Deprecated input character used to specify which level of invariance is
 #' modeled. Users should rely upon constr_dy_x_meas/constr_dy_y_meas and
 #' constr_dy_x_struct/constr_dy_y_struct instead, for making constraints to the measurement and/or structural portions of the model for latent x and y.
-#' @param writescript input logical (default FALSE) for whether lavaan script should
-#' be concatenated and written to current working directory (in subdirectory "scripts")
+#' @param writeTo A character string specifying a directory path to where a .txt file of the resulting lavaan script should be written.
+#' If set to “.”, the .txt file will be written to the current working directory.
+#' The default is a path to a temporary directory created by tempdir().
+#' @param fileName A character string specifying a desired base name for the .txt output file.
+#' The default is "CFM_script". The specified name will be automatically appended with the .txt file extension.
+#' If a file with the same name already exists in the user's chosen directory, it will be overwritten.
 #' @return character object of lavaan script that can be passed immediately to
 #' lavaan functions. Users will receive message if structural comparisons are specified
 #' when the recommended level of invariance is not also specified. If user supplies dvn
@@ -44,7 +48,9 @@
 #' dvn <- scrapeVarCross(dat = commitmentQ, x_order = "spi", x_stem = "sat.g", x_delim1 = ".",
 #' x_delim2="_", distinguish_1="1", distinguish_2="2",
 #' y_order="spi", y_stem="com", y_delim1 = ".", y_delim2="_")
-#' cfm.script.indist <-  scriptCFM(dvn, lvxname = "Sat", lvyname = "Com")
+#' cfm.script.indist <-  scriptCFM(dvn, lvxname = "Sat", lvyname = "Com",
+#' writeTo = tempdir(),
+#' fileName = "CFM_indist")
 
 
 scriptCFM  <- function(dvn, scaleset = "FF",
@@ -55,7 +61,8 @@ scriptCFM  <- function(dvn, scaleset = "FF",
                      constr_dy_y_struct = c("variances", "means"),
                      constr_dy_xy_struct = "none",
                      model = lifecycle::deprecated(),
-                     writescript = FALSE){
+                     writeTo = tempdir(),
+                     fileName = "CFM_script"){
 
   #stop if model is provided
   if (lifecycle::is_present(model)) {
@@ -361,21 +368,23 @@ scriptCFM  <- function(dvn, scaleset = "FF",
                     dyadic)
 
   #Write script to file if requested
-  if(isTRUE(writescript)){
-    dirs("scripts")
-    cat(script,"\n", file = sprintf("./scripts/%s_%s_cfm_x_%s_y_%s_xy_%s.txt",
-                                    lvxname, lvyname,
-                                    paste0(paste0(constr_dy_x_meas, collapse = "_"),
-                                           "_",
-                                           paste0(constr_dy_x_struct, collapse = "_"),
-                                           collapse = "_"),
-                                    paste0(paste0(constr_dy_y_meas, collapse = "_"),
-                                           "_",
-                                           paste0(constr_dy_y_struct, collapse = "_"),
-                                           collapse = "_"),
-                                    paste0(constr_dy_xy_struct, collapse = "_")))
+  
+  # checking for valid directory path and fileName
+  if (!is.character(writeTo)){
+    stop("The `writeout` argument must be a character string. \n Use writeTo = '.' to save script in the current working directory, for example.")
   }
-
+  if (!dir.exists(writeTo)){ 
+    stop("The specified directory does not exist. \n Use writeTo = '.' to save script in the current working directory, for example.")
+  }
+  if (!is.character(fileName)){
+    stop("The `fileName` argument must be a character string.")
+  }
+  
+  cat(script, "\n", 
+      file = sprintf("%s/%s.txt",
+                     writeTo, 
+                     fileName))
+  
   return(script)
 
 }

--- a/R/scriptINULL.R
+++ b/R/scriptINULL.R
@@ -7,8 +7,12 @@
 #' @param dvn input dvn list from scrapeVarCross
 #' @param lvxname input character to (arbitrarily) name X LV in lavaan syntax
 #' @param lvyname (optional) input character to (arbitrarily) name Y LV in lavaan syntax
-#' @param writescript input logical (default FALSE) for whether lavaan script should
-#' be concatenated and written to current working directory (in subdirectory "scripts")
+#' @param writeTo A character string specifying a directory path to where a .txt file of the resulting lavaan script should be written.
+#' If set to “.”, the .txt file will be written to the current working directory.
+#' The default is a path to a temporary directory created by tempdir().
+#' @param fileName A character string specifying a desired base name for the .txt output file.
+#' The default is "I-NULL_script". The specified name will be automatically appended with the .txt file extension.
+#' If a file with the same name already exists in the user's chosen directory, it will be overwritten.
 #' @return character object of lavaan script that can be passed immediately to
 #' lavaan functions
 #' @seealso \code{\link{scrapeVarCross}} which this function relies on
@@ -17,8 +21,12 @@
 #' @examples
 #' dvn <- scrapeVarCross(dat = DRES, x_order = "sip", x_stem = "PRQC", x_delim1 = "_",
 #' x_delim2=".", x_item_num="\\d+", distinguish_1="1", distinguish_2="2")
-#' qual.inull.script <- scriptINULL(dvn, lvxname = "Qual")
-scriptINULL = function(dvn, lvxname = "X", lvyname = NULL, writescript =FALSE){
+#' qual.inull.script <- scriptINULL(dvn, lvxname = "Qual",
+#' writeTo = tempdir(),
+#' fileName = "I-NULL_script")
+scriptINULL = function(dvn, lvxname = "X", lvyname = NULL, 
+                       writeTo = tempdir(),
+                       fileName = "I-NULL_script"){
 
   #Intercepts equated between partners
   xints1 = intercepts(dvn, lvar = "X", partner = "1", type  = "equated")
@@ -88,6 +96,19 @@ scriptINULL = function(dvn, lvxname = "X", lvyname = NULL, writescript =FALSE){
     covars = paste(covars, collapse = "\n")
   }
 
+  
+  # checking for valid directory path and fileName
+  if (!is.character(writeTo)){
+    stop("The `writeout` argument must be a character string. \n Use writeTo = '.' to save script in the current working directory, for example.")
+  }
+  if (!dir.exists(writeTo)){ 
+    stop("The specified directory does not exist. \n Use writeTo = '.' to save script in the current working directory, for example.")
+  }
+  if (!is.character(fileName)){
+    stop("The `fileName` argument must be a character string.")
+  }
+  
+  
   #Script Creation Syntax
   if(length(dvn) == 6){
     INULL.script = sprintf("#Equated Means\n%s\n%s\n\n#Equated Variances\n%s\n%s\n\n#No Covariances\n%s",
@@ -95,21 +116,21 @@ scriptINULL = function(dvn, lvxname = "X", lvyname = NULL, writescript =FALSE){
                            xvars1, xvars2,
                            covars)
 
-    if(isTRUE(writescript)){
-      dirs("scripts")
-      cat(INULL.script,"\n", file = sprintf("./scripts/%s_INULL.txt",lvxname))
-    }
-
+    cat(INULL.script,"\n", 
+        file = sprintf("%s/%s.txt",
+                       writeTo, 
+                       fileName))
+    
   }else if(length(dvn) == 9){
     INULL.script = sprintf("#Equated Means\n%s\n%s\n%s\n%s\n\n#Equated Variances\n%s\n%s\n%s\n%s\n\n#No Covariances\n%s",
                            xints1, xints2, yints1, yints2,
                            xvars1, xvars2, yvars1, yvars2,
                            covars)
 
-    if(isTRUE(writescript)){
-      dirs("scripts")
-      cat(INULL.script,"\n", file = sprintf("./scripts/%s_%s_INULL.txt",lvxname, lvyname))
-    }
+    cat(INULL.script,"\n", 
+        file = sprintf("%s/%s.txt",
+                       writeTo, 
+                       fileName))
   }
 
   return(INULL.script)

--- a/R/scriptISAT.R
+++ b/R/scriptISAT.R
@@ -7,8 +7,12 @@
 #' @param dvn input dvn list from scrapeVarCross
 #' @param lvxname input character to (arbitrarily) name X LV in lavaan syntax
 #' @param lvyname (optional) input character to (arbitrarily) name X LV in lavaan syntax
-#' @param writescript input logical (default FALSE) for whether lavaan script should
-#' be concatenated and written to current working directory (in subdirectory "scripts")
+#' @param writeTo A character string specifying a directory path to where a .txt file of the resulting lavaan script should be written.
+#' If set to “.”, the .txt file will be written to the current working directory.
+#' The default is a path to a temporary directory created by tempdir().
+#' @param fileName A character string specifying a desired base name for the .txt output file.
+#' The default is "I-SAT_script". The specified name will be automatically appended with the .txt file extension.
+#' If a file with the same name already exists in the user's chosen directory, it will be overwritten.
 #' @return character object of lavaan script that can be passed immediately to
 #' lavaan functions
 #' @seealso \code{\link{scrapeVarCross}} which this function relies on
@@ -17,8 +21,13 @@
 #' @examples
 #' dvn <- scrapeVarCross(dat = DRES, x_order = "sip", x_stem = "PRQC", x_delim1 = "_",
 #' x_delim2=".", x_item_num="\\d+", distinguish_1="1", distinguish_2="2")
-#' qual.isat.script <- scriptISAT(dvn, lvxname = "Qual")
-scriptISAT = function(dvn, lvxname = "X", lvyname = NULL, writescript = FALSE){
+#' 
+#' qual.isat.script <- scriptISAT(dvn, lvxname = "Qual",
+#' writeTo = tempdir(),
+#' fileName = "I-SAT_script")
+scriptISAT = function(dvn, lvxname = "X", lvyname = NULL, 
+                      writeTo = tempdir(),
+                      fileName = "I-SAT_script"){
 
   #Intercepts equated between partners
   xints1 = intercepts(dvn, lvar = "X", partner = "1", type  = "equated")
@@ -303,6 +312,20 @@ scriptISAT = function(dvn, lvxname = "X", lvyname = NULL, writescript = FALSE){
     yfree.cor = paste(yfree.cor, collapse = "\n")
   }
 
+  
+  
+  
+  # checking for valid directory path and fileName
+  if (!is.character(writeTo)){
+    stop("The `writeout` argument must be a character string. \n Use writeTo = '.' to save script in the current working directory, for example.")
+  }
+  if (!dir.exists(writeTo)){ 
+    stop("The specified directory does not exist. \n Use writeTo = '.' to save script in the current working directory, for example.")
+  }
+  if (!is.character(fileName)){
+    stop("The `fileName` argument must be a character string.")
+  }
+  
   #Script Creation Syntax
   if(length(dvn) == 6){
     ISAT.script = sprintf("#Constrained Means\n%s\n%s\n\n#Constrained Variances\n%s\n%s\n\n#Constrained Intrapersonal Covariances\n%s\n\n\n%s\n\n#Constrained Interpersonal Covariancesn\n%s\n\n%s\n\n#Estimate Same-Indicator Covariances\n%s",
@@ -312,11 +335,11 @@ scriptISAT = function(dvn, lvxname = "X", lvyname = NULL, writescript = FALSE){
                           xinter1covs, xinter2covs,
                           xfree.cor)
 
-    if(isTRUE(writescript)){
-      dirs("scripts")
-      cat(ISAT.script,"\n", file = sprintf("./scripts/%s_ISAT.txt",lvxname))
-    }
-
+    cat(ISAT.script,"\n", 
+        file = sprintf("%s/%s.txt",
+                       writeTo, 
+                       fileName))
+    
   }else if(length(dvn) == 9){
     ISAT.script = sprintf("#Constrained Means\n%s\n%s\n\n%s\n%s\n\n#Constrained Variances\n%s\n%s\n\n%s\n%s\n\n#Constrained Intrapersonal Covariances\n%s\n\n\n%s\n\n%s\n\n\n%s\n\n#Constrained Interpersonal Covariancesn\n%s\n\n%s\n\n%s\n\n%s\n\n#Estimate Same-Indicator Covariances\n%s\n\n%s",
                           xints1, xints2, yints1, yints2,
@@ -325,11 +348,11 @@ scriptISAT = function(dvn, lvxname = "X", lvyname = NULL, writescript = FALSE){
                           xinter1covs, xinter2covs, yinter1covs, yinter2covs,
                           xfree.cor, yfree.cor)
 
-    if(isTRUE(writescript)){
-      dirs("scripts")
-      cat(ISAT.script,"\n", file = sprintf("./scripts/%s_%s_ISAT.txt",lvxname, lvyname))
-      }
-
+    cat(ISAT.script,"\n", 
+        file = sprintf("%s/%s.txt",
+                       writeTo, 
+                       fileName))
+    
   }
 
   return(ISAT.script)

--- a/R/scriptMIM.R
+++ b/R/scriptMIM.R
@@ -36,8 +36,12 @@
 #' @param est_k input logical for whether Kenny & Ledermann's (2010) k parameter should be
 #' calculated to characterize the dyadic pattern in the APIM. Defaults FALSE, and requires at least
 #' a loading-invariant model to be specified, otherwise a warning is returned.
-#' @param writescript input logical (default FALSE) for whether lavaan script should
-#' be concatenated and written to current working directory (in subdirectory "scripts")
+#' @param writeTo A character string specifying a directory path to where a .txt file of the resulting lavaan script should be written.
+#' If set to “.”, the .txt file will be written to the current working directory.
+#' The default is a path to a temporary directory created by tempdir().
+#' @param fileName A character string specifying a desired base name for the .txt output file.
+#' The default is "MIM_script". The specified name will be automatically appended with the .txt file extension.
+#' If a file with the same name already exists in the user's chosen directory, it will be overwritten.
 #' @return character object of lavaan script that can be passed immediately to
 #' lavaan functions. Users will receive message if structural comparisons are specified
 #' when the recommended level of invariance is not also specified. If user supplies dvn
@@ -50,7 +54,9 @@
 #' x_delim2="_", distinguish_1="1", distinguish_2="2",
 #' y_order="spi", y_stem="com", y_delim1 = ".", y_delim2="_")
 #'
-#' mim.script.indist <- scriptMIM(dvn, lvxname = "Sat", lvyname = "Com", est_k = TRUE)
+#' mim.script.indist <- scriptMIM(dvn, lvxname = "Sat", lvyname = "Com", est_k = TRUE,
+#' writeTo = tempdir(),
+#' fileName = "MIM_indist")
 
 scriptMIM <- function(dvn, scaleset = "FF",
                      lvxname, lvyname,
@@ -60,7 +66,8 @@ scriptMIM <- function(dvn, scaleset = "FF",
                      constr_dy_y_struct = c("variances", "means"),
                      constr_dy_xy_struct = c("actors", "partners"),
                      model = lifecycle::deprecated(), equate = lifecycle::deprecated(), est_k = FALSE,
-                     writescript = FALSE){
+                     writeTo = tempdir(),
+                     fileName = "MIM_script"){
 
 
   #stop if model is provided
@@ -383,21 +390,23 @@ scriptMIM <- function(dvn, scaleset = "FF",
   }
 
   #Write script to file if requested
-  if(isTRUE(writescript)){
-    dirs("scripts")
-    cat(script,"\n", file = sprintf("./scripts/%s_%s_apim_x_%s_y_%s_xy_%s.txt",
-                                    lvxname, lvyname,
-                                    paste0(paste0(constr_dy_x_meas, collapse = "_"),
-                                           "_",
-                                           paste0(constr_dy_x_struct, collapse = "_"),
-                                           collapse = "_"),
-                                    paste0(paste0(constr_dy_y_meas, collapse = "_"),
-                                           "_",
-                                           paste0(constr_dy_y_struct, collapse = "_"),
-                                           collapse = "_"),
-                                    paste0(constr_dy_xy_struct, collapse = "_")))
+  
+  # checking for valid directory path and fileName
+  if (!is.character(writeTo)){
+    stop("The `writeout` argument must be a character string. \n Use writeTo = '.' to save script in the current working directory, for example.")
   }
-
+  if (!dir.exists(writeTo)){ 
+    stop("The specified directory does not exist. \n Use writeTo = '.' to save script in the current working directory, for example.")
+  }
+  if (!is.character(fileName)){
+    stop("The `fileName` argument must be a character string.")
+  }
+  
+  cat(script, "\n", 
+      file = sprintf("%s/%s.txt",
+                     writeTo, 
+                     fileName))
+  
   return(script)
 }
 

--- a/R/scriptObsAPIM.R
+++ b/R/scriptObsAPIM.R
@@ -8,8 +8,12 @@
 #' @param equate character of what parameter(s) to constrain ("actor", "partner", "all"); default is "none" (all freely estimated)
 #' @param k input logical for whether Kenny & Ledermann's (2010) k parameter should be
 #' calculated to characterize the dyadic pattern in the APIM. Default to FALSE
-#' @param writescript input logical (default FALSE) for whether lavaan script should
-#' be concatenated and written to current working directory (in subdirectory "scripts")
+#' @param writeTo A character string specifying a directory path to where a .txt file of the resulting lavaan script should be written.
+#' If set to “.”, the .txt file will be written to the current working directory.
+#' The default is a path to a temporary directory created by tempdir().
+#' @param fileName A character string specifying a desired base name for the .txt output file.
+#' The default is "obsAPIM_script". The specified name will be automatically appended with the .txt file extension.
+#' If a file with the same name already exists in the user's chosen directory, it will be overwritten.
 #'
 #' @return character object of lavaan script that can be passed immediately to
 #' lavaan functions.
@@ -19,12 +23,15 @@
 #'
 #' obsAPIMScript <- scriptObsAPIM (X1 = "SexSatA", Y1 = "RelSatA",
 #' X2 = "SexSatB", Y2 = "RelSatB",
-#' equate = "none")
+#' equate = "none",
+#' writeTo = tempdir(), 
+#' fileName = "obsAPIM_script")
 #'
 scriptObsAPIM <- function(X1 = NULL, Y1 = NULL,
                           X2 = NULL, Y2 = NULL,
                           equate = "none", k = FALSE,
-                          writescript = FALSE){
+                          writeTo = tempdir(),
+                          fileName = "obsAPIM_script"){
 
   if(equate == "none"){
     reg1 <- paste0(Y1, " ~ a1*", X1, " + p1*", X2)
@@ -98,9 +105,21 @@ scriptObsAPIM <- function(X1 = NULL, Y1 = NULL,
     }
   }
 
-  if(isTRUE(writescript)){
-    cat(apimScript,"\n", file = sprintf("./scripts/observed_apim_equate_%s_k_%s.txt",equate, k))
+  # checking for valid directory path and fileName
+  if (!is.character(writeTo)){
+    stop("The `writeout` argument must be a character string. \n Use writeTo = '.' to save script in the current working directory, for example.")
   }
-
+  if (!dir.exists(writeTo)){ 
+    stop("The specified directory does not exist. \n Use writeTo = '.' to save script in the current working directory, for example.")
+  }
+  if (!is.character(fileName)){
+    stop("The `fileName` argument must be a character string.")
+  }
+  
+  cat(apimScript, "\n", 
+      file = sprintf("%s/%s.txt",
+                     writeTo, 
+                     fileName))
+  
   return(apimScript)
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -147,7 +147,9 @@ summary(qual.indist.fit, fit.measures = TRUE, standardized = TRUE, rsquare = TRU
 ```{r outputModel, eval = FALSE}
 outputModel(dvn, model = "cfa", fit = qual.indist.fit, 
             table = TRUE, tabletype = "measurement", 
-            figure = TRUE, figtype = "unstandardized")
+            figure = TRUE, figtype = "unstandardized",
+            writeTo = tempdir(),
+            fileName = "dCFA_indist")
 ```
 
 ## Code of Conduct

--- a/README.md
+++ b/README.md
@@ -195,7 +195,9 @@ path diagrams and/or tables of statistical values.
 ``` r
 outputModel(dvn, model = "cfa", fit = qual.indist.fit, 
             table = TRUE, tabletype = "measurement", 
-            figure = TRUE, figtype = "unstandardized")
+            figure = TRUE, figtype = "unstandardized",
+            writeTo = tempdir(),
+            fileName = "dCFA_indist")
 ```
 
 ## Code of Conduct

--- a/man/outputModel.Rd
+++ b/man/outputModel.Rd
@@ -12,7 +12,8 @@ outputModel(
   tabletype = NULL,
   figure = TRUE,
   figtype = NULL,
-  writeout = FALSE
+  writeTo = tempdir(),
+  fileName = NULL
 )
 }
 \arguments{
@@ -33,8 +34,14 @@ options are "measurement" (i.e,, loadings, intercepts,),
 
 \item{figtype}{character input of what type of figure is desired}
 
-\item{writeout}{logical (default is FALSE) for whether outputted table and/or figure
-should be written to an output subdirectory in current working directory}
+\item{writeTo}{A character string specifying a directory path to where the file(s) should be saved.
+If set to “.”, the file(s) will be written to the current working directory.
+The default is a path to a temporary directory created by tempdir().}
+
+\item{fileName}{A character string specifying a desired base name for the output file(s).
+If a \code{fileName} not provided (i.e., "fileName = NULL"), then defaults will be used
+(e.g., "dySEM_table"/"dySEM_table_Measurement"/"dySEM_table_Structural for tables; "dySEM_figure" for figures).
+The specified name will be automatically appended with the appropriate file extension (i.e., .rtf for tables; .png for figures).}
 }
 \value{
 Ignore console (prints unnecessary semPlot::semPaths details). More importantly,
@@ -43,6 +50,10 @@ prints word files for the table(s) and/or figure, outputted to the users working
 \description{
 This function takes the  model from fitted dySEM() scripts and
 exports table(s) and/or a path diagram figure of expected output.
+}
+\details{
+If a file with the same name already exists in the user's chosen directory,
+it will be overwritten.
 }
 \examples{
 dvnx <- scrapeVarCross(dat = commitmentQ, x_order = "spi", x_stem = "sat.g", x_delim1 = ".",
@@ -53,8 +64,10 @@ constr_dy_struct = "none")
 
 sat.config.mod <- lavaan::cfa(sat.config.script, data = commitmentQ, std.lv = FALSE,
 auto.fix.first= FALSE, meanstructure = TRUE)
+
 outputModel(dvnx, model = "cfa", fit = sat.config.mod, table = TRUE,
-tabletype = "measurement", figure = "TRUE", figtype = "standardized")
+tabletype = "measurement", figure = "TRUE", figtype = "standardized", 
+writeTo = tempdir(), fileName = "dCFA_configural")
 dvnxy <- scrapeVarCross(dat = commitmentQ, x_order = "spi", x_stem = "sat.g", x_delim1 = ".",
 x_delim2="_", distinguish_1="1", distinguish_2="2",
 y_order="spi", y_stem="com", y_delim1 = ".", y_delim2="_")
@@ -65,5 +78,6 @@ apim.indist.mod <- lavaan::cfa(apim.indist.script, data = commitmentQ, std.lv = 
 auto.fix.first= FALSE, meanstructure = TRUE)
 
 outputModel(dvnxy, model = "apim", fit = apim.indist.mod, table = TRUE,
-tabletype = "measurement", figure = "TRUE", figtype = "standardized")
+tabletype = "measurement", figure = "TRUE", figtype = "standardized", 
+writeTo = tempdir(), fileName = "APIM_indist")
 }

--- a/man/scriptAPIM.Rd
+++ b/man/scriptAPIM.Rd
@@ -18,7 +18,8 @@ scriptAPIM(
   model = lifecycle::deprecated(),
   equate = lifecycle::deprecated(),
   est_k = FALSE,
-  writescript = FALSE
+  writeTo = tempdir(),
+  fileName = "latAPIM_script"
 )
 }
 \arguments{
@@ -64,8 +65,13 @@ constraints to the structural portion of the model for associative relationship 
 calculated to characterize the dyadic pattern in the APIM. Defaults FALSE, and requires at least
 a loading-invariant model to be specified, otherwise a warning is returned.}
 
-\item{writescript}{input logical (default FALSE) for whether lavaan script should
-be concatenated and written to current working directory (in subdirectory "scripts")}
+\item{writeTo}{A character string specifying a directory path to where a .txt file of the resulting lavaan script should be written.
+If set to “.”, the .txt file will be written to the current working directory.
+The default is a path to a temporary directory created by tempdir().}
+
+\item{fileName}{A character string specifying a desired base name for the .txt output file.
+The default is "latAPIM_script". The specified name will be automatically appended with the .txt file extension.
+If a file with the same name already exists in the user's chosen directory, it will be overwritten.}
 }
 \value{
 character object of lavaan script that can be passed immediately to
@@ -84,7 +90,9 @@ measurement models, and particular types of structural comparisons.
 dvn <- scrapeVarCross(dat = commitmentQ, x_order = "spi", x_stem = "sat.g", x_delim1 = ".",
 x_delim2="_", distinguish_1="1", distinguish_2="2",
 y_order="spi", y_stem="com", y_delim1 = ".", y_delim2="_")
-apim.script.indist <-  scriptAPIM(dvn, lvxname = "Sat", lvyname = "Com", est_k = TRUE)
+apim.script.indist <-  scriptAPIM(dvn, lvxname = "Sat", lvyname = "Com", est_k = TRUE,
+writeTo = tempdir(),
+fileName = "latAPIM_indist")
 }
 \seealso{
 \code{\link{scrapeVarCross}} which this function relies on

--- a/man/scriptBiDy.Rd
+++ b/man/scriptBiDy.Rd
@@ -17,7 +17,8 @@ scriptBiDy(
   constr_dy_xy_struct = c("actors"),
   model = lifecycle::deprecated(),
   equate = lifecycle::deprecated(),
-  writescript = FALSE
+  writeTo = tempdir(),
+  fileName = "BiDy_script"
 )
 }
 \arguments{
@@ -60,8 +61,13 @@ constr_dy_x_struct/constr_dy_y_struct instead, for making constraints to the mea
 are constrained to equivalency between partners. Users should rely upon constr_dy_xy_struct for making
 constraints to the structural portion of the model for associative relationship between latent x and y.}
 
-\item{writescript}{input logical (default FALSE) for whether lavaan script should
-be concatenated and written to current working directory (in subdirectory "scripts")}
+\item{writeTo}{A character string specifying a directory path to where a .txt file of the resulting lavaan script should be written.
+If set to “.”, the .txt file will be written to the current working directory.
+The default is a path to a temporary directory created by tempdir().}
+
+\item{fileName}{A character string specifying a desired base name for the .txt output file.
+The default is "BiDy_script". The specified name will be automatically appended with the .txt file extension.
+If a file with the same name already exists in the user's chosen directory, it will be overwritten.}
 }
 \value{
 character object of lavaan script that can be passed immediately to
@@ -77,13 +83,18 @@ BiDy CFA (BiDy-C) or SEM (BiDy-S) Model. Currently only uses fixed-factor scale-
 dvn <- scrapeVarCross(DRES, x_order = "sip", x_stem = "sexsat",
 x_delim2=".", distinguish_1="1", distinguish_2="2")
 
-sexsat.bidyc.script <- scriptBiDy(dvn, lvxname = "SexSat", type = "CFA")
+sexsat.bidyc.script <- scriptBiDy(dvn, lvxname = "SexSat", type = "CFA",
+writeTo = tempdir(),
+fileName = "BiDy_C")
+
 dvn <- scrapeVarCross(dat = commitmentQ, x_order = "spi", x_stem = "sat.g", x_delim1 = ".",
 x_delim2="_", distinguish_1="1", distinguish_2="2",
 y_order="spi", y_stem="com", y_delim1 = ".", y_delim2="_")
 
 comsat.bidys.config.script <- scriptBiDy(dvn, lvxname = "Sat",
-lvyname = "Com", type = "SEM")
+lvyname = "Com", type = "SEM",
+writeTo = tempdir(),
+fileName = "BiDy_S")
 }
 \seealso{
 Other script-writing functions: 

--- a/man/scriptCFA.Rd
+++ b/man/scriptCFA.Rd
@@ -12,7 +12,8 @@ scriptCFA(
   constr_dy_meas = c("loadings", "intercepts", "residuals"),
   constr_dy_struct = c("variances", "means"),
   model = lifecycle::deprecated(),
-  writescript = FALSE
+  writeTo = tempdir(),
+  fileName = "dCFA_script"
 )
 }
 \arguments{
@@ -36,8 +37,13 @@ but user can specify any combination of "variances" and "means", or "none".}
 modeled ("configural", "loading", "intercept", "residual", or "indist"). Users should rely upon constr_dy_meas and
 constr_dy_struct instead, for making constraints to the measurement and/or structural portions of the model.}
 
-\item{writescript}{input logical (default FALSE) for whether lavaan script should
-be concatenated and written to current working directory (in subdirectory "scripts")}
+\item{writeTo}{A character string specifying a directory path to where a .txt file of the resulting lavaan script should be written.
+If set to “.”, the .txt file will be written to the current working directory.
+The default is a path to a temporary directory created by tempdir().}
+
+\item{fileName}{A character string specifying a desired base name for the .txt output file.
+The default is "dCFA_script". The specified name will be automatically appended with the .txt file extension.
+If a file with the same name already exists in the user's chosen directory, it will be overwritten.}
 }
 \value{
 character object of lavaan script that can be passed immediately to
@@ -74,19 +80,27 @@ constr_dy_struct = "variances")
 
 sat.resids.script <- scriptCFA(dvn, lvname = "Sat",
 constr_dy_meas = c("loadings", "intercepts", "residuals"),
-constr_dy_struct = "none")
+constr_dy_struct = "none",
+writeTo = tempdir(),
+fileName = "dCFA_residual")
 
 sat.ints.script <- scriptCFA(dvn, lvname = "Sat",
 constr_dy_meas = c("loadings", "intercepts"),
-constr_dy_struct = "none")
+constr_dy_struct = "none",
+writeTo = tempdir(),
+fileName = "dCFA_intercept")
 
 sat.loads.script <- scriptCFA(dvn, lvname = "Sat",
 constr_dy_meas = c("loadings"),
-constr_dy_struct = "none")
+constr_dy_struct = "none",
+writeTo = tempdir(),
+fileName = "dCFA_loading")
 
 sat.config.script <- scriptCFA(dvn, lvname = "Sat",
 constr_dy_meas = "none",
-constr_dy_struct = "none")
+constr_dy_struct = "none",
+writeTo = tempdir(),
+fileName = "dCFA_configural")
 }
 \seealso{
 \code{\link{scrapeVarCross}} which this function relies on

--- a/man/scriptCFM.Rd
+++ b/man/scriptCFM.Rd
@@ -16,7 +16,8 @@ scriptCFM(
   constr_dy_y_struct = c("variances", "means"),
   constr_dy_xy_struct = "none",
   model = lifecycle::deprecated(),
-  writescript = FALSE
+  writeTo = tempdir(),
+  fileName = "CFM_script"
 )
 }
 \arguments{
@@ -55,8 +56,13 @@ partners' latent x and y. Defaults to "none". Options include "p1_zero" or "p2_z
 modeled. Users should rely upon constr_dy_x_meas/constr_dy_y_meas and
 constr_dy_x_struct/constr_dy_y_struct instead, for making constraints to the measurement and/or structural portions of the model for latent x and y.}
 
-\item{writescript}{input logical (default FALSE) for whether lavaan script should
-be concatenated and written to current working directory (in subdirectory "scripts")}
+\item{writeTo}{A character string specifying a directory path to where a .txt file of the resulting lavaan script should be written.
+If set to “.”, the .txt file will be written to the current working directory.
+The default is a path to a temporary directory created by tempdir().}
+
+\item{fileName}{A character string specifying a desired base name for the .txt output file.
+The default is "CFM_script". The specified name will be automatically appended with the .txt file extension.
+If a file with the same name already exists in the user's chosen directory, it will be overwritten.}
 }
 \value{
 character object of lavaan script that can be passed immediately to
@@ -75,7 +81,9 @@ measurement models, and particular types of structural comparisons.
 dvn <- scrapeVarCross(dat = commitmentQ, x_order = "spi", x_stem = "sat.g", x_delim1 = ".",
 x_delim2="_", distinguish_1="1", distinguish_2="2",
 y_order="spi", y_stem="com", y_delim1 = ".", y_delim2="_")
-cfm.script.indist <-  scriptCFM(dvn, lvxname = "Sat", lvyname = "Com")
+cfm.script.indist <-  scriptCFM(dvn, lvxname = "Sat", lvyname = "Com",
+writeTo = tempdir(),
+fileName = "CFM_indist")
 }
 \seealso{
 \code{\link{scrapeVarCross}} which this function relies on

--- a/man/scriptINULL.Rd
+++ b/man/scriptINULL.Rd
@@ -5,7 +5,13 @@
 \title{A Function That Writes, Saves, and Exports Syntax for
 Fitting the I-NULL model for indistinguishable dyads}
 \usage{
-scriptINULL(dvn, lvxname = "X", lvyname = NULL, writescript = FALSE)
+scriptINULL(
+  dvn,
+  lvxname = "X",
+  lvyname = NULL,
+  writeTo = tempdir(),
+  fileName = "I-NULL_script"
+)
 }
 \arguments{
 \item{dvn}{input dvn list from scrapeVarCross}
@@ -14,8 +20,13 @@ scriptINULL(dvn, lvxname = "X", lvyname = NULL, writescript = FALSE)
 
 \item{lvyname}{(optional) input character to (arbitrarily) name Y LV in lavaan syntax}
 
-\item{writescript}{input logical (default FALSE) for whether lavaan script should
-be concatenated and written to current working directory (in subdirectory "scripts")}
+\item{writeTo}{A character string specifying a directory path to where a .txt file of the resulting lavaan script should be written.
+If set to “.”, the .txt file will be written to the current working directory.
+The default is a path to a temporary directory created by tempdir().}
+
+\item{fileName}{A character string specifying a desired base name for the .txt output file.
+The default is "I-NULL_script". The specified name will be automatically appended with the .txt file extension.
+If a file with the same name already exists in the user's chosen directory, it will be overwritten.}
 }
 \value{
 character object of lavaan script that can be passed immediately to
@@ -29,7 +40,9 @@ for the I-NULL model described in Olsen & Kenny (2006)
 \examples{
 dvn <- scrapeVarCross(dat = DRES, x_order = "sip", x_stem = "PRQC", x_delim1 = "_",
 x_delim2=".", x_item_num="\\\\d+", distinguish_1="1", distinguish_2="2")
-qual.inull.script <- scriptINULL(dvn, lvxname = "Qual")
+qual.inull.script <- scriptINULL(dvn, lvxname = "Qual",
+writeTo = tempdir(),
+fileName = "I-NULL_script")
 }
 \seealso{
 \code{\link{scrapeVarCross}} which this function relies on

--- a/man/scriptISAT.Rd
+++ b/man/scriptISAT.Rd
@@ -5,7 +5,13 @@
 \title{A Function That Writes, Saves, and Exports Syntax for
 Fitting the I-SAT model for indistinguishable dyads}
 \usage{
-scriptISAT(dvn, lvxname = "X", lvyname = NULL, writescript = FALSE)
+scriptISAT(
+  dvn,
+  lvxname = "X",
+  lvyname = NULL,
+  writeTo = tempdir(),
+  fileName = "I-SAT_script"
+)
 }
 \arguments{
 \item{dvn}{input dvn list from scrapeVarCross}
@@ -14,8 +20,13 @@ scriptISAT(dvn, lvxname = "X", lvyname = NULL, writescript = FALSE)
 
 \item{lvyname}{(optional) input character to (arbitrarily) name X LV in lavaan syntax}
 
-\item{writescript}{input logical (default FALSE) for whether lavaan script should
-be concatenated and written to current working directory (in subdirectory "scripts")}
+\item{writeTo}{A character string specifying a directory path to where a .txt file of the resulting lavaan script should be written.
+If set to “.”, the .txt file will be written to the current working directory.
+The default is a path to a temporary directory created by tempdir().}
+
+\item{fileName}{A character string specifying a desired base name for the .txt output file.
+The default is "I-SAT_script". The specified name will be automatically appended with the .txt file extension.
+If a file with the same name already exists in the user's chosen directory, it will be overwritten.}
 }
 \value{
 character object of lavaan script that can be passed immediately to
@@ -29,7 +40,10 @@ for the I-SAT model described in Olsen & Kenny (2006)
 \examples{
 dvn <- scrapeVarCross(dat = DRES, x_order = "sip", x_stem = "PRQC", x_delim1 = "_",
 x_delim2=".", x_item_num="\\\\d+", distinguish_1="1", distinguish_2="2")
-qual.isat.script <- scriptISAT(dvn, lvxname = "Qual")
+
+qual.isat.script <- scriptISAT(dvn, lvxname = "Qual",
+writeTo = tempdir(),
+fileName = "I-SAT_script")
 }
 \seealso{
 \code{\link{scrapeVarCross}} which this function relies on

--- a/man/scriptMIM.Rd
+++ b/man/scriptMIM.Rd
@@ -18,7 +18,8 @@ scriptMIM(
   model = lifecycle::deprecated(),
   equate = lifecycle::deprecated(),
   est_k = FALSE,
-  writescript = FALSE
+  writeTo = tempdir(),
+  fileName = "MIM_script"
 )
 }
 \arguments{
@@ -64,8 +65,13 @@ constraints to the structural portion of the model for associative relationship 
 calculated to characterize the dyadic pattern in the APIM. Defaults FALSE, and requires at least
 a loading-invariant model to be specified, otherwise a warning is returned.}
 
-\item{writescript}{input logical (default FALSE) for whether lavaan script should
-be concatenated and written to current working directory (in subdirectory "scripts")}
+\item{writeTo}{A character string specifying a directory path to where a .txt file of the resulting lavaan script should be written.
+If set to “.”, the .txt file will be written to the current working directory.
+The default is a path to a temporary directory created by tempdir().}
+
+\item{fileName}{A character string specifying a desired base name for the .txt output file.
+The default is "MIM_script". The specified name will be automatically appended with the .txt file extension.
+If a file with the same name already exists in the user's chosen directory, it will be overwritten.}
 }
 \value{
 character object of lavaan script that can be passed immediately to
@@ -85,7 +91,9 @@ dvn <- scrapeVarCross(dat = commitmentQ, x_order = "spi", x_stem = "sat.g", x_de
 x_delim2="_", distinguish_1="1", distinguish_2="2",
 y_order="spi", y_stem="com", y_delim1 = ".", y_delim2="_")
 
-mim.script.indist <- scriptMIM(dvn, lvxname = "Sat", lvyname = "Com", est_k = TRUE)
+mim.script.indist <- scriptMIM(dvn, lvxname = "Sat", lvyname = "Com", est_k = TRUE,
+writeTo = tempdir(),
+fileName = "MIM_indist")
 }
 \seealso{
 \code{\link{scrapeVarCross}} which this function relies on

--- a/man/scriptObsAPIM.Rd
+++ b/man/scriptObsAPIM.Rd
@@ -12,7 +12,8 @@ scriptObsAPIM(
   Y2 = NULL,
   equate = "none",
   k = FALSE,
-  writescript = FALSE
+  writeTo = tempdir(),
+  fileName = "obsAPIM_script"
 )
 }
 \arguments{
@@ -29,8 +30,13 @@ scriptObsAPIM(
 \item{k}{input logical for whether Kenny & Ledermann's (2010) k parameter should be
 calculated to characterize the dyadic pattern in the APIM. Default to FALSE}
 
-\item{writescript}{input logical (default FALSE) for whether lavaan script should
-be concatenated and written to current working directory (in subdirectory "scripts")}
+\item{writeTo}{A character string specifying a directory path to where a .txt file of the resulting lavaan script should be written.
+If set to “.”, the .txt file will be written to the current working directory.
+The default is a path to a temporary directory created by tempdir().}
+
+\item{fileName}{A character string specifying a desired base name for the .txt output file.
+The default is "obsAPIM_script". The specified name will be automatically appended with the .txt file extension.
+If a file with the same name already exists in the user's chosen directory, it will be overwritten.}
 }
 \value{
 character object of lavaan script that can be passed immediately to
@@ -44,6 +50,8 @@ Fitting Observed Actor-Partner Interdependence Models
 
 obsAPIMScript <- scriptObsAPIM (X1 = "SexSatA", Y1 = "RelSatA",
 X2 = "SexSatB", Y2 = "RelSatB",
-equate = "none")
+equate = "none",
+writeTo = tempdir(), 
+fileName = "obsAPIM_script")
 
 }

--- a/vignettes/articles/apim.Rmd
+++ b/vignettes/articles/apim.Rmd
@@ -70,7 +70,7 @@ apim.script.config <-  scriptAPIM(dvn, #the list we just created from scrapeVarC
                                   constr_dy_y_struct = "none", #no structural constraints for latent y
                                   constr_dy_xy_struct = "none", #no constrained actor and/or partner effects
                                   est_k = TRUE,#want k-parameter? (optional, but nice)
-                                  writescript = FALSE) #want script saved to directory? (e.g., for OSF?)
+                                  writeTo = tempdir(), fileName = "APIM_script_config") #want script saved to directory? (e.g., for OSF?)
 
 apim.fit.config <- cfa(apim.script.config, 
                                data = dat,
@@ -150,7 +150,7 @@ apim.script.config <-  scriptAPIM(dvn, #the list we just created from scrapeVarC
                                   constr_dy_y_struct = "none", #no structural constraints for latent y
                                   constr_dy_xy_struct = "none", #no constrained actor and/or partner effects
                                   est_k = TRUE,#want k-parameter? (optional, but nice)
-                                  writescript = FALSE) #want script saved to directory? (e.g., for OSF?)
+                                  writeTo = tempdir(), fileName = "APIM_script_config") #want script saved to directory? (e.g., for OSF?)
 
 ```
 
@@ -214,7 +214,7 @@ apim.script.config.actpart <-  scriptAPIM(dvn, #the list we just created from sc
                                   constr_dy_y_struct = "none", #no structural constraints for latent y
                                   constr_dy_xy_struct = c("actors", "partners"), # constrained actor and/or partner effects
                                   est_k = TRUE,#want k-parameter? (optional, but nice)
-                                  writescript = FALSE) #want script saved to directory? (e.g., for OSF?)
+                                  writeTo = tempdir(), fileName = "APIM_script_config") #want script saved to directory? (e.g., for OSF?)
 
 ```
 
@@ -231,7 +231,7 @@ apim.script.loads.actpart <-  scriptAPIM(dvn, #the list we just created from scr
                                   constr_dy_y_struct = "none", #no structural constraints for latent y
                                   constr_dy_xy_struct = c("actors", "partners"), # constrained actor and/or partner effects
                                   est_k = TRUE,#want k-parameter? (optional, but nice)
-                                  writescript = FALSE) #want script saved to directory? (e.g., for OSF?)
+                                  writeTo = tempdir(), fileName = "APIM_script_loading") #want script saved to directory? (e.g., for OSF?)
 
 apim.fit.loads.eq.all <- cfa(apim.script.loads.actpart, 
                                data = commitmentQ,

--- a/vignettes/dySEM.Rmd
+++ b/vignettes/dySEM.Rmd
@@ -210,7 +210,7 @@ You can learn about what other kinds of detail you can extract from a fitted `la
 
 The `outputModel` function is currently `dySEM`'s all-purpose outputting function. 
 
-The useR must specify the `dvn` of scraped variables used to script the model and the type of model being outputted (e.g., "cfa"). UseRs can specify whether they only want a path diagram or some table(s) to be outputted (e.g., by setting either `figure = FALSE` or `table = FALSE`), but by default both are created and written to an `output` folder in your working directory. UseRs can further specify what kind of path diagram (e.g., using standardized or unstandardized value) or tables (e.g., featuring measurement- or structural-model parameter, or both) are created.
+The useR must specify the `dvn` of scraped variables used to script the model and the type of model being outputted (e.g., "cfa"). UseRs can specify whether they only want a path diagram or some table(s) to be outputted (e.g., by setting either `figure = FALSE` or `table = FALSE`), but by default both are created. UseRs can specify a directory path to where they want their file(s) to be written and saved (e.g., setting `writeTo = "."` to save in the current working directory). UseRs can further specify what kind of path diagram (e.g., using standardized or unstandardized value) or tables (e.g., featuring measurement- or structural-model parameter, or both) are created.
 
 Whatever options the useR specifies, `outputModel` is typically run without assigning its output to an object, as it's mostly to facilitate statistical reporting for scientific articles: 
 
@@ -218,5 +218,6 @@ Whatever options the useR specifies, `outputModel` is typically run without assi
 ```{r dyoutput, eval = FALSE}
 outputModel(dvn, model = "cfa", fit = qual.config.fit, 
             table = TRUE, tabletype = "measurement", 
-            figure = TRUE, figtype = "unstandardized")
+            figure = TRUE, figtype = "unstandardized",
+            writeTo = tempdir(), fileName = "dCFA_config")
 ```


### PR DESCRIPTION
Addresses Issue #111 

Also addresses comments in Pull Request #112  

Summary:
- Created a `writeTo` argument for the scripters and `outputModel()`, which will replace `writescript` and `writeout`. The default of `writeTo` is set to `tempdir()`.
- Created a `fileName` argument for the scripters and `outputModel()` -- allowing users to specify a desired base name for their output file (the appropriate file extension gets appended automatically). If users do not provide a `fileName`, then defaults will be used (e.g., “latAPIM_script”, “obsAPIM_script”, “dySEM_table”, etc.). 
- Made updates to the function documentation, README, and vignettes.
- Ran `devtools::check` and received zero complaints.
