### PR TITLE
Fix: updated default arguments for `writeTo` and `fileName` in `scriptMIM()` and `scriptObsAPIM()`. Feat: updated documentation and error message in `outputModel()`

### DIFF
--- a/R/outputModel.R
+++ b/R/outputModel.R
@@ -15,7 +15,7 @@
 #' @param figtype character input of what type of figure is desired
 #' @param writeTo A character string specifying a directory path to where the file(s) should be saved.
 #' If set to “.”, the file(s) will be written to the current working directory.
-#' The default is NULL, and examples use a temporary directory created by tempdir().
+#' The default is NULL (which will throw an error), and examples use a temporary directory created by tempdir().
 #' @param fileName A character string specifying a desired base name for the output file(s).
 #' If a `fileName` not provided (i.e., default fileName = NULL), then defaults will be used
 #' (e.g., "dySEM_table"/"dySEM_table_Measurement"/"dySEM_table_Structural for tables; "dySEM_figure" for figures).
@@ -60,6 +60,9 @@ outputModel  <-  function(dvn, model = NULL, fit,
                     fileName = NULL){
 
   # checking for valid directory path
+  if (is.null(writeTo)){
+    stop("Must specify a directory to which the file should be saved. \n Use writeout = '.' to save output file(s) in the current working directory.")
+  }
   if (!is.character(writeTo)){
     stop("The `writeTo` argument must be a character string. \n Use writeTo = '.' to save output file(s) in the current working directory.")
   }

--- a/R/scriptMIM.R
+++ b/R/scriptMIM.R
@@ -66,8 +66,8 @@ scriptMIM <- function(dvn, scaleset = "FF",
                      constr_dy_y_struct = c("variances", "means"),
                      constr_dy_xy_struct = c("actors", "partners"),
                      model = lifecycle::deprecated(), equate = lifecycle::deprecated(), est_k = FALSE,
-                     writeTo = tempdir(),
-                     fileName = "MIM_script"){
+                     writeTo = NULL,
+                     fileName = NULL){
 
 
   #stop if model is provided

--- a/R/scriptObsAPIM.R
+++ b/R/scriptObsAPIM.R
@@ -30,8 +30,8 @@
 scriptObsAPIM <- function(X1 = NULL, Y1 = NULL,
                           X2 = NULL, Y2 = NULL,
                           equate = "none", k = FALSE,
-                          writeTo = tempdir(),
-                          fileName = "obsAPIM_script"){
+                          writeTo = NULL,
+                          fileName = NULL){
 
   if(equate == "none"){
     reg1 <- paste0(Y1, " ~ a1*", X1, " + p1*", X2)

--- a/man/outputModel.Rd
+++ b/man/outputModel.Rd
@@ -36,7 +36,7 @@ options are "measurement" (i.e,, loadings, intercepts,),
 
 \item{writeTo}{A character string specifying a directory path to where the file(s) should be saved.
 If set to “.”, the file(s) will be written to the current working directory.
-The default is NULL, and examples use a temporary directory created by tempdir().}
+The default is NULL (which will throw an error), and examples use a temporary directory created by tempdir().}
 
 \item{fileName}{A character string specifying a desired base name for the output file(s).
 If a \code{fileName} not provided (i.e., default fileName = NULL), then defaults will be used

--- a/man/scriptMIM.Rd
+++ b/man/scriptMIM.Rd
@@ -18,8 +18,8 @@ scriptMIM(
   model = lifecycle::deprecated(),
   equate = lifecycle::deprecated(),
   est_k = FALSE,
-  writeTo = tempdir(),
-  fileName = "MIM_script"
+  writeTo = NULL,
+  fileName = NULL
 )
 }
 \arguments{

--- a/man/scriptObsAPIM.Rd
+++ b/man/scriptObsAPIM.Rd
@@ -12,8 +12,8 @@ scriptObsAPIM(
   Y2 = NULL,
   equate = "none",
   k = FALSE,
-  writeTo = tempdir(),
-  fileName = "obsAPIM_script"
+  writeTo = NULL,
+  fileName = NULL
 )
 }
 \arguments{


### PR DESCRIPTION
Related to Issue #111 and PR #113.

Scritpers
- Updated `scriptMIM()` and `scriptObsAPIM()` to have `writeTo = NULL` and `fileName = NULL` as defaults (just like the other scripters).

`outputModel()`
- Since `writeTo = NULL` is the default and will throw an error, I included a small note mentioning that in the documentation – i.e., “The default is NULL (which will throw an error) …”
- I also included a new error message that is more specific to those situations: so, if `writeTo = NULL`, instead of the error message saying “The `writeTo` argument must be a character string….”, the error message will say “Must specify a directory to which the file should be saved….”
