### PR TITLE
docs: minor polish to the CDFM, M-CDFM, and L-APIM tutorials

### DIFF
--- a/vignettes/articles/CDFM.Rmd
+++ b/vignettes/articles/CDFM.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Fitting and Interpretting the Correlated Dyadic Factors Model (CDFM)"
+title: "Fitting and Interpreting the Correlated Dyadic Factors Model (CDFM)"
 ---
 
 ```{r, include = FALSE}
@@ -9,37 +9,37 @@ knitr::opts_chunk$set(
 )
 ```
 
-## Fair Use of this Tutorial 
+## Fair Use of this Tutorial
 
-This tutorial is a supplemental material from the following article: 
+This tutorial is a supplemental material from the following article:
 
-Sakaluk, J. K., & Camanto, O. J. (2025). *Dyadic Data Analysis via Structural Equation Modeling with Latent Variables: A Tutorial with the dySEM package for R*. 
+Sakaluk, J. K., & Camanto, O. J. (2025). *Dyadic Data Analysis via Structural Equation Modeling with Latent Variables: A Tutorial with the dySEM package for R*.
 
-This article is intended to serve as the primary citation of record for the dySEM package's functionality for the techniques described in this tutorial. **If this tutorial has informed your modeling strategy (including but not limited to your use of `dySEM`), please cite this article**. 
+This article is intended to serve as the primary citation of record for the `dySEM` package's functionality for the techniques described in this tutorial. **If this tutorial has informed your modeling strategy (including but not limited to your use of `dySEM`), please cite this article**.
 
-The citation of research software aiding in analyses--like the use of `dySEM`--is a required practice, according to the **Journal Article Reporting Standards (JARS) for Quantitative Research in Psychology** ([Appelbaum et al., 2018](https://psycnet.apa.org/fulltext/2018-00750-002.html)). 
+The citation of research software aiding in analyses---like the use of `dySEM`---is a required practice, according to the **Journal Article Reporting Standards (JARS) for Quantitative Research in Psychology** ([Appelbaum et al., 2018](https://psycnet.apa.org/fulltext/2018-00750-002.html)).
 
-Furthermore, citations remain essential for our development team to demonstrate the impact of our work to our local institutions and our funding sources, and with your support, we will be able to continue justifying our time and efforts spent improving `dySEM` and expanding its reach. 
+Furthermore, citations remain essential for our development team to demonstrate the impact of our work to our local institutions and our funding sources, and with your support, we will be able to continue justifying our time and efforts spent improving `dySEM` and expanding its reach.
 
 ## Overview
 
-The CDFM is a **"uni-construct"** dyadic SEM (i.e., used to represent dyadic data about one--and only one--construct, like "relationship satisfaction"). 
+The CDFM is a **"uni-construct"** dyadic SEM (i.e., used to represent dyadic data about one---and only one---construct, like "relationship satisfaction").
 
 It contains:
 
--  two latent variables/factors, onto which 
--  each partner's observed variables discriminantly load (i.e., one partner's observed variables onto their factor, and the other partner's observed variables onto their factor)
+-   two latent variables/factors, onto which
+-   each partner's observed variables discriminantly load (i.e., one partner's observed variables onto their factor, and the other partner's observed variables onto their factor)
 
 It also features two varieties of covariances (or correlations, depending on scale-setting/output standardization):
 
--  one between the two latent variables (effectively, the latent intraclass correlation coefficient), and 
--  several between the residual variances of the same observed variables across each partner (e.g., between Item 1 for Partner A and Partner B; another between Item 2 for Partner A and Partner B, etc.,). 
+-   one between the two latent variables (effectively, the latent intraclass correlation coefficient [ICC]), and
+-   several between the residual variances of the same observed variables across each partner (e.g., between Item 1 for Partner A and Partner B; another between Item 2 for Partner A and Partner B, etc.,).
 
-Owing to it serving as one half of the measurement model of a latent-APIM--and the APIM being the clear default structural model in relationship science ([Kenny, 2018](https://doi.org/10.1111/pere.12240))--the CDFM could (taciltly) be considered relationship science's "default"--for better and for worse--uni-construct dyadic SEM.
+Owing to it serving as one half of the measurement model of a [latent actor-partner interdependence model (APIM)](https://jsakaluk.github.io/dySEM/articles/L-APIM.html)---and the APIM being the clear default structural model in relationship science ([Kenny, 2018](https://doi.org/10.1111/pere.12240))---the CDFM could (tacitly) be considered relationship science's "default"---for better and for worse---uni-construct dyadic SEM.
 
-## Packages, Data, and dySEM Overview
+## Packages, Data, and `dySEM` Overview
 
-This exemplar makes use of the `tidverse` meta-package, and the  `gt`, `dySEM`, and `lavaan` (Rosseel, 2012) packages. 
+This exemplar makes use of the `tidyverse` meta-package, and the `gt`, `dySEM`, and `lavaan` (Rosseel, 2012) packages.
 
 ```{r setup, message= FALSE}
 library(dplyr) #for data management
@@ -49,11 +49,11 @@ library(lavaan) #for fitting dyadic SEMs
 
 ```
 
-For the exemplar, we will use the built-in `commitmentM` dataset from `dySEM`, which includes ratings of satisfaction and committment from 282 mixed-sex dyads. These data were collected using the "global" version of items for relationship satisfaction from the Rusbult et al. (1998) *Investment Model Scale*. More information about this data set can be found in [Sakaluk et al. (2021)](https://doi.org/10.1111/pere.12341).
+For the exemplar, we will use the built-in [`commitmentM`](https://jsakaluk.github.io/dySEM/reference/commitmentM.html) dataset from `dySEM`, which includes ratings of satisfaction and commitment from 282 mixed-sex dyads. These data were collected using the "global" version of items for relationship satisfaction from the Rusbult et al. (1998) *Investment Model Scale*. More information about this data set can be found in [Sakaluk et al. (2021)](https://doi.org/10.1111/pere.12341).
 
-This dataset already possesses many of the desirable features of a dataset for use with dySEM, as it is in wide format, and the variable names have a repetitive predictable structure (to learn more, see [our tutorial on variable name structure](https://jsakaluk.github.io/dySEM/articles/varnames.html)). Specificially:
+This dataset already possesses many of the desirable features of a dataset for use with `dySEM`, as it is in wide format, and the variable names have a repetitive predictable structure (to learn more, see [our tutorial on variable name structure](https://jsakaluk.github.io/dySEM/articles/varnames.html)). Specifically:
 
--   The *satisfaction* items follow a "sip" pattern (Stem, Item, Partner) with a stem of "sat.g", followed immediately by a number for the item (i.e., no delimeter between these elements), followed by a delimiting "\_", and then either the character "f" or "m to indicate to which partner the item refers. For example, the first satisfaction item for partner 1 is "sat.g1_f", and the first satisfaction item for partner 2 is "sat.g1_m".
+-   The *satisfaction* items follow a "sip" pattern (Stem, Item, Partner) with a stem of "sat.g", followed immediately by a number for the item (i.e., no delimiter between these elements), followed by a delimiting "\_", and then either the character "f" or "m" to indicate to which partner the item refers. For example, the first satisfaction item for partner 1 is "sat.g1_f", and the first satisfaction item for partner 2 is "sat.g1_m".
 
 -   Likewise, the *commitment* items follow a similar "sip" pattern, albeit with a different stem, "com".
 
@@ -70,21 +70,21 @@ my_dat |>
 
 ```
 
-As described in the paper, and the [Get Started tutorial for `dySEM`](https://jsakaluk.github.io/dySEM/articles/dySEM.html) , the steps we must take to carry out dyadic invariance testing with dySEM are:
+As described in the paper, and the [Get Started tutorial for `dySEM`](https://jsakaluk.github.io/dySEM/articles/dySEM.html) , the steps we must take to carry out dyadic invariance testing with `dySEM` are:
 
 1.  **Scrape** the relevant items from the data set, to be included in each CDFM
-2.  **Script** the lavaan syntax for the dyadic configural, loading, interecept, and residual invariance models
-3.  **Fit** the invariance models with lavaan
-4.  generate reproducible **output** of our analyses, and 
-5.  consider the use of **optional** functionality for supplementary indexes and tests that dySEM can compute (we will demonstrate a couple)
+2.  **Script** the `lavaan` syntax for the dyadic configural, loading, intercept, and residual invariance models
+3.  **Fit** the invariance models with `lavaan`
+4.  generate reproducible **output** of our analyses, and
+5.  consider the use of **optional** functionality for supplementary indexes and tests that `dySEM` can compute (we will demonstrate a couple)
 
 ## 1. *Scrape* the Variables
 
-The [`scrapeVarCross`](https://jsakaluk.github.io/dySEM/reference/scrapeVarCross.html) from dySEM is the appropriate function to scrape the variable information needed for automating the scripting of latent dyadic models of cross-sectional data. In this instance, we are only scraping information about indicators about one (pair of) dyadic latent variable(s): men and women's latent relationship satisfaction.
+The [`scrapeVarCross()`](https://jsakaluk.github.io/dySEM/reference/scrapeVarCross.html) from `dySEM` is the appropriate function to scrape the variable information needed for automating the scripting of latent dyadic models of cross-sectional data. In this instance, we are only scraping information about indicators about one (pair of) dyadic latent variable(s): men and women's latent relationship satisfaction.
 
-As described before, the *satisfaction* items follow a ["sip" pattern (Stem, Item, Partner)](https://jsakaluk.github.io/dySEM/articles/varnames.html) with a stem of "sat.g", followed immediately by a number for the item (i.e., no delimeter between these elements), followed by a delimiting "_", and then either the character "f" or "m to indicate to which partner the item refers.
+As described before, the *satisfaction* items follow a ["sip" pattern (Stem, Item, Partner)](https://jsakaluk.github.io/dySEM/articles/varnames.html) with a stem of "sat.g", followed immediately by a number for the item (i.e., no delimiter between these elements), followed by a delimiting "\_", and then either the character "f" or "m" to indicate to which partner the item refers.
 
-We therefore refer to our data frame ("`my_dat`") for the `dat` argument, and the pattern, stem, delimeters (if any), and distinguishing characters for the `x_order`, `x_stem`, `x_delim1`, `x_delim2`, `distinguish_1`, and `distinguish_2` arguments, respectively. In this instance, our stem is "sat.g"; there is no first delimeter, and an "_" for the second delimeter; and the distinguishing characters are "f" and "m".
+We therefore refer to our data frame ("`my_dat`") for the `dat` argument, and the pattern, stem, delimiters (if any), and distinguishing characters for the `x_order`, `x_stem`, `x_delim1`, `x_delim2`, `distinguish_1`, and `distinguish_2` arguments, respectively. In this instance, our stem is "sat.g"; there is no first delimiter, and an "\_" for the second delimiter; and the distinguishing characters are "f" and "m".
 
 We assign the output of this function (a list of variable names an information) to an object we are (arbitrarily) calling "sat_dvn"; *we often refer to this list as a* **"dyad variable names"** *list, or* **"dvn"** *for short*.
 
@@ -96,13 +96,13 @@ sat_dvn
 
 ```
 
-As can be seen, the information contained in the dvn is rather mundane: the indicator names for the "f" partners (e.g., "sat.g1_f"), the indicator names for the "m" partners (e.g., "sat.g5_m"), the number of indicators per partner (in this case, 5), the distinguishing characters ("f" and "m"), and the total number of indicators (10) in the entire set. Yet this information is all that is needed for dySEM to dramatically simplify the process of scripting dyadic SEM models, including dyadic invariance models.
+As can be seen, the information contained in the dvn is rather mundane: the indicator names for the "f" partners (e.g., "sat.g1_f"), the indicator names for the "m" partners (e.g., "sat.g5_m"), the number of indicators per partner (in this case, 5), the distinguishing characters ("f" and "m"), and the total number of indicators (10) in the entire set. Yet this information is all that is needed for `dySEM` to dramatically simplify the process of scripting dyadic SEM models, including dyadic invariance models.
 
 ## 2. *Script* the Model(s)
 
-Next, we will script the dyadic configural, loading, intercept, and residual invariance models. We will use the `scriptCor` function from dySEM to do this. This function requires the `dvn` object we created in the prior step, an arbitrary name for the latent variable for lavaan, and the `constr_dy_meas` and `constr_dy_struct` arguments to indicate which measurement (i.e., "meas") and structural (i.e., "struct") parameters we want to constraint (i.e., "constr") across dyad members (i.e., "dy"). The `scaleset` argument automatically defaults to the fixed-factor scale-setting and identification method, prefered for invariance testing . However, we encourage users who are just beginning to include this argument explicitly, so they (and others) can readily determine their model specification approach.
+Next, we will script the dyadic configural, loading, intercept, and residual invariance models. We will use the [`scriptCor()`](https://jsakaluk.github.io/dySEM/reference/scriptCor.html) function from `dySEM` to do this. This function requires the `dvn` object we created in the prior step, an arbitrary name for the latent variable for `lavaan`, and the `constr_dy_meas` and `constr_dy_struct` arguments to indicate which measurement (i.e., "meas") and structural (i.e., "struct") parameters we want to constraint (i.e., "constr") across dyad members (i.e., "dy"). The `scaleset` argument automatically defaults to the fixed-factor scale-setting and identification method, preferred for invariance testing . However, we encourage users who are just beginning to include this argument explicitly, so they (and others) can readily determine their model specification approach.
 
-Below, we script the sequence of four models to be fit and compared; we forego the use of the `writeTo` and `fileName` arguments, which are used to save the .txt of scripts to a file. Finally, we use an intuitive naming structure to keep track of which model script resides in which R object.
+Below, we script the sequence of four models to be fit and compared; we forego the use of the `writeTo` and `fileName` arguments, which are used to save the `.txt` of scripts to a file. Finally, we use an intuitive naming structure to keep track of which model script resides in which R object.
 
 ```{r, script, echo = TRUE}
 
@@ -116,23 +116,23 @@ sat.resid.script <- scriptCor(sat_dvn, lvname = "Sat", scaleset = "FF", constr_d
 
 ```
 
-In their stored form, these scripts are not particularly readable, but as we shall soon see, they are immediately passable to lavaan:
+In their stored form, these scripts are not particularly readable, but as we shall soon see, they are immediately passable to `lavaan`:
 
 ```{r, print script, echo = TRUE}
 
 sat.resid.script
 ```
 
-However, when exported (via the `writeTo` and `fileName` arguments) or concatenated, they can be presented in a much more readable format that mirrors what users expect from a manually written lavaan script:
+However, when exported (via the `writeTo` and `fileName` arguments) or concatenated, they can be presented in a much more readable format that mirrors what users expect from a manually written `lavaan` script:
 
 ```{r, print script (concatenated), echo = TRUE}
 
 cat(sat.resid.script)
 ```
 
-## 3. *Fit* the Model(s) 
+## 3. *Fit* the Model(s)
 
-All of these models can now be fit with whichever lavaan wrapper the user prefers, and with their chosen analytic options (e.g., estimator, missing data treatment, etc)
+All of these models can now be fit with whichever `lavaan` wrapper the user prefers, and with their chosen analytic options (e.g., estimator, missing data treatment, etc); our demonstration uses default specifications for `cfa()`:
 
 ```{r, fit, echo = TRUE}
 
@@ -157,7 +157,7 @@ anova(sat.config.mod, sat.load.mod, sat.int.mod, sat.resid.mod)
 
 ```
 
-Conversely, they could instead consider the use of `outputInvarCompTab()`, a function we have written to wrap some of the same comparative output in a more reproducible-reporting-friendly format:
+Conversely, they could instead consider the use of [`outputInvarCompTab()`](https://jsakaluk.github.io/dySEM/reference/outputInvarCompTab.html), a function we have written to wrap some of the same comparative output in a more reproducible-reporting-friendly format:
 
 ```{r, mod comp, echo = TRUE}
 
@@ -166,7 +166,7 @@ mods <- list(sat.config.mod, sat.load.mod, sat.int.mod, sat.resid.mod)
 outputInvarCompTab(mods)
 ```
 
-Without additional arguemntation, `outputInvarCompTab()` (and other outputters in `dySEM`) return data frames; these are the most flexible output types to supply to other tabling and/or visualization functionality. However, users looking for a more expedient way to "clean up" reporting from outputters can either make use of the `gtTab` argument; TRUE will return a basic gt table which can then be further modified using additional `gt` layers. This is a good option for reproducible reporting document formats (like .Rmd and .Qmd):
+Without additional argumentation, `outputInvarCompTab()` (and other outputters in `dySEM`) return data frames; these are the most flexible output types to supply to other tabling and/or visualization functionality. However, users looking for a more expedient way to "clean up" reporting from outputters can either make use of the `gtTab` argument; `TRUE` will return a basic `gt` table which can then be further modified using additional `gt` layers. This is a good option for reproducible reporting document formats (like .Rmd and .Qmd):
 
 ```{r, mod comp gt, echo = TRUE}
 
@@ -174,7 +174,7 @@ outputInvarCompTab(mods, gtTab = TRUE)
 
 ```
 
-Conversely, if users prefer to export the output to a file, they can set the additional `writeTo` argument to a directory path (a path of "." will write to the user's current working directory, like that associated with an .Rproj file), and the `fileName` argument to a desired base name for the output file. This will save the output as an .rtf file in that directory, which can then be opened in Microsoft Word or other word processing software:
+Conversely, if users prefer to export the output to a file, they can set the additional `writeTo` argument to a directory path (a path of "." will write to the user's current working directory, like that associated with an .Rproj file), and the `fileName` argument to a desired base name for the output file. This will save the output as an `.rtf` file in that directory, which can then be opened in Microsoft Word or other word processing software:
 
 ```{r mod comp write, include = TRUE, eval = FALSE}
 
@@ -194,7 +194,7 @@ p <- round(comp$pr_chisq, 2)
 
 Were one strictly to follow only the likelihood ratio test statistic as a guide, they might feel comfortable claiming they have reasonable support for most forms of dyadic invariance, with the exception of significant residual noninvariances, $\chi^2$ (`r comp$df_diff[4]`) = `r chisq_diff[4]`, *p* = `r p[4]`.
 
-Users can then request that *dySEM* provide them with reproducible output via either the `outputParamTab()` (for tabular output) or the `outputParamFig()` (for a path diagram, back-ended by *semPlot*). For example, if one wanted a table of measurement model output from the dyadic intercept invariance model they could use:
+Users can then request that `dySEM` provide them with reproducible output via either the [`outputParamTab()`](https://jsakaluk.github.io/dySEM/reference/outputParamTab.html) (for tabular output) or the [`outputParamFig()`](https://jsakaluk.github.io/dySEM/reference/outputParamFig.html) (for a path diagram, back-ended by `semPlot`). For example, if one wanted a table of measurement model output from the dyadic intercept invariance model they could use:
 
 ```{r, outputTable, echo = TRUE}
 
@@ -203,16 +203,15 @@ outputParamTab(sat_dvn, model = "cfa", fit = sat.int.mod,
   gt()
 ```
 
-The `model` and `tabletype` arguments are the main providers of optionality to be aware of, as outputParamTab is also used to provide tabular output from other model types (e.g., APIMs), and users may be most interested in the output from one portion of the model (e.g., the measurement model) versus another (e.g., the structural model).
+The `model` and `tabletype` arguments are the main providers of optionality to be aware of, as `outputParamTab()` is also used to provide tabular output from other model types (e.g., APIMs), and users may be most interested in the output from one portion of the model (e.g., the measurement model) versus another (e.g., the structural model).
 
-Path diagrams, meanwhile, are created with the `outputParamFig()` function, which is used in a similar manner to `outputParamTab()` (and includes the same `writeTo` and `fileName` arguments if you wish to export a .png). Otherwise, the primary argument to be aware of is `figtype`, which allows users to specify what kind of parameter estimates they wish to be depicted in the path diagram.
+Path diagrams, meanwhile, are created with the `outputParamFig()` function, which is used in a similar manner to `outputParamTab()` (and includes the same `writeTo` and `fileName` arguments if you wish to export a `.png`). Otherwise, the primary argument to be aware of is `figtype`, which allows users to specify what kind of parameter estimates they wish to be depicted in the path diagram.
 
 ```{r, outputFigure, echo = TRUE}
 
 outputParamFig(fit = sat.int.mod, figtype = "standardized")
 
 ```
-
 
 ```{r, latent_corr, include = FALSE}
 
@@ -225,13 +224,13 @@ params <- params |>
 
 ```
 
-Thus, in little more than a dozen lines of code, researchers can script, fit, compare, and output a series of dyadic invariance comparisons using the Correlated Dyadic Factors Model. From this, researchers would learn that the satisfaction measure demonstrates reasonable configural, loading, and intercept invariance between partners, and that the latent ICC between partner's satisfaction levels is `r params$std.all`, z = `r params$z`, p `r if(params$p < .001){paste("<.001")}` (95% CI: `r params$ci.lower`, `r params$ci.upper`).
+Thus, in little more than a dozen lines of code, researchers can script, fit, compare, and output a series of dyadic invariance comparisons using the Correlated Dyadic Factors Model. From this, researchers would learn that the satisfaction measure demonstrates reasonable configural, loading, and intercept invariance between partners, and that the latent ICC between partner's satisfaction levels is `r params$std.all`, *z* = `r params$z`, *p* `r if(params$p < .001){paste("<.001")}` (95% CI: `r params$ci.lower`, `r params$ci.upper`).
 
 ## 5. Consider *Optional* Indexes and Output
 
-A remaining question would be: if our chosen model fails to demonstrate residual invariance, which indicator(s) are responsible for introducing the noninvariance? The `outputConstraintTab()` function from dySEM, while not strictly necessary, offers supplemental functionality to help answer this question.
+A remaining question would be: if our chosen model fails to demonstrate residual invariance, which indicator(s) are responsible for introducing the noninvariance? The [`outputConstraintTab()`](https://jsakaluk.github.io/dySEM/reference/outputConstraintTab.html) function from `dySEM`, while not strictly necessary, offers supplemental functionality to help answer this question.
 
-Users simply enter the lavaan model responsible for the statistically significant degradation of model fit, and are provided with a table of each dyadic invariance constraint, by indicator, and its Langrange multiplier test statistic and corresponding test:
+Users simply enter the `lavaan` model responsible for the statistically significant degradation of model fit, and are provided with a table of each dyadic invariance constraint, by indicator, and its Lagrange multiplier test statistic and corresponding test:
 
 ```{r, outputConstraintTab, echo = TRUE}
 
@@ -240,4 +239,4 @@ outputConstraintTab(sat.resid.mod) |>
 
 ```
 
-In this particular instance, significant noninvariance was only introduced by forcing the constraint on the residual variances for the 1st and 5th items
+In this particular instance, significant noninvariance was only introduced by forcing the constraint on the residual variances for the 1st and 5th items.

--- a/vignettes/articles/L-APIM.Rmd
+++ b/vignettes/articles/L-APIM.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Fitting and Interpretting the Latent Actor-Partner Interdependence Model (L-APIM)"
+title: "Fitting and Interpreting the Latent Actor-Partner Interdependence Model (L-APIM)"
 ---
 
 ```{r, include = FALSE}
@@ -15,15 +15,15 @@ This tutorial is a supplemental material from the following article:
 
 Sakaluk, J. K., & Camanto, O. J. (2025). *Dyadic Data Analysis via Structural Equation Modeling with Latent Variables: A Tutorial with the dySEM package for R*. 
 
-This article is intended to serve as the primary citation of record for the dySEM package's functionality for the techniques described in this tutorial. **If this tutorial has informed your modeling strategy (including but not limited to your use of `dySEM`), please cite this article**. 
+This article is intended to serve as the primary citation of record for the `dySEM` package's functionality for the techniques described in this tutorial. **If this tutorial has informed your modeling strategy (including but not limited to your use of `dySEM`), please cite this article**. 
 
-The citation of research software aiding in analyses--like the use of `dySEM`--is a required practice, according to the Journal Article Reporting Standards (JARS) for Quantitative Research in Psychology ([Appelbaum et al., 2018](https://psycnet.apa.org/fulltext/2018-00750-002.html)). 
+The citation of research software aiding in analyses---like the use of `dySEM`---is a required practice, according to the Journal Article Reporting Standards (JARS) for Quantitative Research in Psychology ([Appelbaum et al., 2018](https://psycnet.apa.org/fulltext/2018-00750-002.html)). 
 
 Furthermore, citations remain essential for our development team to demonstrate the impact of our work to our local institutions and our funding sources, and with your support, we will be able to continue justifying our time and efforts spent improving `dySEM` and expanding its reach. 
 
 ## Overview
 
-The L-APIM is a **"bi-construct"** dyadic SEM (i.e., used to represent dyadic data about two constructs--like latent relationship satisfaction and latent relationship commitment). 
+The L-APIM is a **"bi-construct"** dyadic SEM (i.e., used to represent dyadic data about two constructs---like latent relationship satisfaction and latent relationship commitment). 
 
 It contains:
 
@@ -41,11 +41,13 @@ Finally, and most distinctively, it also features a few slopes, of different kin
 -   "actor" effects are slopes estimated from each partner's latent predictor to their own latent outcome (e.g., Partner A's latent relationship satisfaction predicting their own latent relationship commitment, and Partner B's latent relationship satisfaction predicting their own latent relationship commitment),
 -   "partner" effects are slopes estimated from each partner's latent predictor to their partner's latent outcome (e.g., Partner A's latent relationship satisfaction predicting Partner B's latent relationship commitment, and Partner B's latent relationship satisfaction predicting Partner A's latent relationship commitment)
 
-These slopes maybe estimated separately for each partner (i.e., producing unique actor and partner effect for each partner) to produce a "distinguishable" L-APIM, or some or all of these slopes may be constrained (i.e., producing a shared/pooled effect for a given slope(s)) introduce some level of "indistinguishability" to the structural model. Further, sometimes researchers are interested in estimating a boutique parameter that captures the ratio between actor and partner effects--the *k* parameter--in order to characterize the "pattern" of dyadic effects.
+These slopes may be estimated separately for each partner (i.e., producing unique actor and partner effect for each partner) to produce a "distinguishable" L-APIM, or some or all of these slopes may be constrained (i.e., producing a shared/pooled effect for a given slope(s)) introduce some level of "indistinguishability" to the structural model. Further, sometimes researchers are interested in estimating a boutique parameter that captures the ratio between actor and partner effects---the *k* parameter---in order to characterize the "pattern" of dyadic effects.
 
-The observed (i.e., non-latent) APIM is, by an incredibly wide margin, the most popular bi-construct dyadic data model. Though the L-APIM is not as popular (likely owing to its increased programming difficulty--a barrier we hope *dySEM* helps to remove), it is well-suited to address the problems that measurement error and statistical control interactively introduce that would otherwise contaminate the insights of the observed APIM. It also enables researchers to simultaneously appraise dyadic invariance for both the latent predictors and latent outcomes--a tacit assumption of informative comparisons of actor and partner effects across partners and the estimation of the *k* parameter.
+The observed (i.e., non-latent) APIM is, by an incredibly wide margin, the most popular bi-construct dyadic data model. Though the L-APIM is not as popular (likely owing to its increased programming difficulty---a barrier we hope `dySEM` helps to remove), it is well-suited to address the problems that measurement error and statistical control interactively introduce that would otherwise contaminate the insights of the observed APIM. It also enables researchers to simultaneously appraise dyadic invariance for both the latent predictors and latent outcomes---a tacit assumption of informative comparisons of actor and partner effects across partners and the estimation of the *k* parameter.
 
 ## Packages and Data
+
+This exemplar makes use of the `dplyr`, `janitor`, `gt`, `dySEM`, and `lavaan` (Rosseel, 2012) packages, as well as the development version of the `dynamic` package.
 
 ```{r setup, message= FALSE}
 library(dplyr) #for data management
@@ -59,7 +61,7 @@ library(lavaan) #for fitting dyadic SEMs
 
 ```
 
-For this exemplar, we use the `commitmentQ` dataset from dySEM, collected using the "global" version of items for relationship satisfaction from the Rusbult et al. (1998) *Investment Model Scale*. This dataset includes the very same items as the `commitmentM` data set used in the exemplar for the CDFM, except responses come from 118 LGBTQ+ dyads (distinguished by partner "1" or "2") and the variable naming elements [follow a “spi” pattern](https://jsakaluk.github.io/dySEM/articles/varnames.html). In this bi-construct exemplar, we will make use of both the responses to the satisfaction and commitment items:
+For this exemplar, we use the [`commitmentQ`](https://jsakaluk.github.io/dySEM/reference/commitmentQ.html) dataset from `dySEM`, collected using the "global" version of items for relationship satisfaction from the Rusbult et al. (1998) *Investment Model Scale*. This dataset includes the very same items as the [`commitmentM`](https://jsakaluk.github.io/dySEM/reference/commitmentM.html) data set used in the exemplar for the [CDFM](https://jsakaluk.github.io/dySEM/articles/CDFM.html), except responses come from 118 LGBTQ+ dyads (distinguished by partner "1" or "2") and the variable naming elements [follow a “spi” pattern](https://jsakaluk.github.io/dySEM/articles/varnames.html). In this bi-construct exemplar, we will make use of both the responses to the satisfaction and commitment items:
 
 ```{r data}
 com_dat <- commitmentQ
@@ -70,7 +72,7 @@ com_dat |>
 
 ## 1. Scraping the Variables
 
-We first scrape the satisfaction and commitment indicators with `scrapeVarCross()`; when two constructs have information for their indicators scraped, researchers can make use of the `y_` arguments (e.g., `y_order`, `y_stem`) that parallel the `x_` arguments for specifying the variable naming pattern that x (satisfaction) and y (commitment) indicators follow (though the function currently presumes that the same distinguishing characters--in this case, "1' and "2") are used for both x and y indicators):
+We first scrape the satisfaction and commitment indicators with [`scrapeVarCross()`](https://jsakaluk.github.io/dySEM/reference/scrapeVarCross.html); when two constructs have information for their indicators scraped, researchers can make use of the `y_` arguments (e.g., `y_order`, `y_stem`) that parallel the `x_` arguments for specifying the variable naming pattern that x (satisfaction) and y (commitment) indicators follow (though the function currently presumes that the same distinguishing characters---in this case, "1' and "2"---are used for both x and y indicators):
 
 ```{r, scrape commitmentQ items, echo = TRUE}
 
@@ -82,13 +84,13 @@ apim_dvn <- scrapeVarCross(dat = com_dat,
 
 ## 2. Scripting the Model(s)
 
-Scripting latent APIMs is subsequently expeditious with the `scriptAPIM()` function. All that is required is a “dvn” of scraped information for x- and y- indicators, and (arbitrary) names for the latent X and latent Y variables. Users then can invoke whatever optional argumentation they wish to control dyadic measurement invariance constraints for either their x- and/or y-indicators through the `constr_dy_x_meas` and `constr_dy_y_meas` arguments. Likewise, structural level equality constraints on features of latent x and latent y (i.e., variances and means) are controlled through `constr_dy_x_struct` and `constr_dy_y_struct`, while users control equality constraints on the latent slopes (i.e., actor and/or partner effects) through the `constr_dy_xy_struct` argument. 
+Scripting L-APIMs is subsequently expeditious with the [`scriptAPIM()`](https://jsakaluk.github.io/dySEM/reference/scriptAPIM.html) function. All that is required is a “dvn” of scraped information for x- and y- indicators, and (arbitrary) names for the latent X and latent Y variables. Users then can invoke whatever optional argumentation they wish to control dyadic measurement invariance constraints for their x- and/or y-indicators through the `constr_dy_x_meas` and `constr_dy_y_meas` arguments. Likewise, structural level equality constraints on features of latent x and latent y (i.e., variances and means) are controlled through `constr_dy_x_struct` and `constr_dy_y_struct`, while users control equality constraints on the latent slopes (i.e., actor and/or partner effects) through the `constr_dy_xy_struct` argument. 
 
-In an effort to boost the inclusivity of dyadic data analysis methods (Sakaluk et al., 2025), `scriptAPIM()` defaults to a fully indistinguishable model—one in which loadings, intercepts, residuals, latent variances, latent means, and latent slopes are all constrained to be equal across dyad members. The burden is thereby placed on researchers to provide evidence for a less parsimonious model (Kenny et al., 2006), by manually specifying less constrained models and testing against the fully indistinguishable model as a baseline. Finally, scriptAPIM() enables researchers to optionally estimate the k parameter (Kenny & Ledermann, 2010) based on the latent slopes, by setting the `est_k` argument to `TRUE`; the estimation of k is programmed to automatically adjust depending what constraints, if any, are made on actor and/or partner effects. 
+In an effort to boost the inclusivity of dyadic data analysis methods (Sakaluk et al., 2025), `scriptAPIM()` defaults to a fully indistinguishable model—one in which loadings, intercepts, residuals, latent variances, latent means, and latent slopes are all constrained to be equal across dyad members. The burden is thereby placed on researchers to provide evidence for a less parsimonious model (Kenny et al., 2006), by manually specifying less constrained models and testing against the fully indistinguishable model as a baseline. Finally, `scriptAPIM()` enables researchers to optionally estimate the *k* parameter (Kenny & Ledermann, 2010) based on the latent slopes, by setting the `est_k` argument to `TRUE`; the estimation of *k* is programmed to automatically adjust depending what constraints, if any, are made on actor and/or partner effects. 
 
-Any model generated by `scriptAPIM()` can be outputted to a .txt file for transparent sharing of research materials, through the use of the optional `writeTo` and `fileName` arguments.
+Any model generated by `scriptAPIM()` can be outputted to a `.txt` file for transparent sharing of research materials, through the use of the optional `writeTo` and `fileName` arguments.
 
-Here, we depict the process of fitting competing latent APIMs that have indistinguishable measurement models, latent variances, and means, while indulging different patterns of actor- and partner-effects, and estimating k in each model:
+Here, we depict the process of fitting competing L-APIMs that have indistinguishable measurement models, latent variances, and means, while indulging different patterns of actor- and partner-effects, and estimating *k* in each model:
 
 ```{r, script latent APIMs, echo = TRUE}
 
@@ -109,7 +111,7 @@ apim.script.free.actpart <-  scriptAPIM(apim_dvn, lvxname = "Sat", lvyname = "Co
 
 ## 3. Fitting the Model(s) 
 
-We can then pass these scripted models to lavaan for model fitting:
+We can then pass these scripted models to `lavaan` for model fitting:
 
 ```{r fit latent APIMS, echo = TRUE}
 apim.fit.indist <- cfa(apim.script.indist, data = com_dat)
@@ -131,7 +133,7 @@ comp_act <- janitor::clean_names(comp_act)
 comp_part <- janitor::clean_names(comp_part)
 comp_actpart <- janitor::clean_names(comp_actpart)
 
-#rounding for reporitng
+#rounding for reporting
 chisq_diff_act <- round(comp_act$chisq_diff, 2)
 p_act <- round(comp_act$pr_chisq, 2)
 
@@ -146,7 +148,7 @@ mis_actpart <- fitMeasures(apim.fit.free.actpart, c("rmsea", "cfi"))
 
 Interestingly, while neither freely estimating the actor paths, $\chi^2$ (`r comp_act$df_diff[2]`) = `r chisq_diff_act[2]`, *p* = `r p_act[2]`, or partner paths, $\chi^2$ (`r comp_part$df_diff[2]`) = `r chisq_diff_part[2]`, *p* = `r p_part[2]`, significantly improved the fit of the model, freely estimating both actor and partner paths did, $\chi^2$ (`r comp_actpart$df_diff[2]`) = `r chisq_diff_actpart[2]`, *p* = `r p_actpart[2]`. That said, the freely estimated model did not fit the data particularly well according to traditional model fit cutoffs (Hu & Bentler, 1999), with RMSEA = `r round(mis_actpart[1], 3)` and CFI = `r round(mis_actpart[2],3)`.
 
-`outputParamFig()` makes it easy to visualize the parameter estimates from the L-APIM, via *semPlot* package (Epskamp, 2015):
+[`outputParamFig()`](https://jsakaluk.github.io/dySEM/reference/outputParamFig.html) makes it easy to visualize the parameter estimates from the L-APIM, via `semPlot` package (Epskamp, 2015):
 
 ```{r, apim figure, echo = TRUE}
 
@@ -154,7 +156,7 @@ outputParamFig(fit = apim.fit.free.actpart, figtype = "unstandardized")
 
 ```
 
-Likewise, `outputParamTab()` provides reproducible tables of APIM output, and can be directed to provide only structural model output (as we demonstrate), measurement model output, or both:
+Likewise, [`outputParamTab()`](https://jsakaluk.github.io/dySEM/reference/outputParamTab.html) provides reproducible tables of APIM output, and can be directed to provide only structural model output (as we demonstrate), measurement model output, or both:
 
 ```{r, apim table, echo = TRUE}
 
@@ -164,11 +166,11 @@ outputParamTab(apim_dvn, model = "apim", fit = apim.fit.free.actpart,
 
 ```
 
-In this instance, the output suggests that whereas Partner 2’s level of satisfaction is a significant predictor of their own commitment (a2) and their partner’s (p1), Partner 1’s level of satisfaction is not a significant predictor of either partner’s level of commitment. Meanwhile, Partner 1’s k parameter is so imprecise (owing to its modest actor effect) that its confidence interval spans all possible dyadic patterns, while Partner 2’s k parameter is more indicative of an actor-only pattern (0), such that we can reject the possibility of either a contrast-pattern (-1) or a couple-pattern (1).  
+In this instance, the output suggests that whereas Partner 2’s level of satisfaction is a significant predictor of their own commitment (a2) and their partner’s (p1), Partner 1’s level of satisfaction is not a significant predictor of either partner’s level of commitment. Meanwhile, Partner 1’s *k* parameter is so imprecise (owing to its modest actor effect) that its confidence interval spans all possible dyadic patterns, while Partner 2’s *k* parameter is more indicative of an actor-only pattern (0), such that we can reject the possibility of either a contrast-pattern (-1) or a couple-pattern (1).  
 
 ## 5. Optional Indexes and Output
 
-This exemplar of the latent APIM also serves to briefly demonstrate the benefits of building dySEM on top of the foundation of lavaan, as any core or external improvement or modernation for lavaan-based functionality can thereby benefit dySEM. McNeish’s work (McNeish et al., 2018), for example, has brought appropriate renewed attention to the limits of depending on the cutoffs for model fit indexes that were popularized, most successfully, by Hu and Bentler (Hu & Bentler, 1999). Subsequently, McNeish and colleagues have provided lavaan-friendly functionality to calculate so-called “dynamic” fit indexes, which identify simulation-generated targets for model fit indexes that are calibrated a given fitted model (McNeish, 2023; McNeish & Manapat, 2024; McNeish & Wolf, 2022, 2023). More recently, McNeish and Wolf have proposed Direct Discrepancy Dynamic Fit Index (“DD-DFI” or “3DFI”) cutoffs, which are robust in application across many kinds of fitted models, response scales, estimators, and missing data conditions (McNeish & Wolf, 2024). And with their *dynamic* package for R, **it is quite straightforward to use 3DFIs, with** ***dySEM***, **to perform a more rigorous appraisal of the fit of our selected latent APIMs: a practice that, whenever possible, we recommend as the default approach for the appraisal of dyadic SEMs with** ***dySEM*** **when their features match the requirements of 3DFIs**—namely, in the absence of a mean structure. 
+This exemplar of the L-APIM also serves to briefly demonstrate the benefits of building `dySEM` on top of the foundation of `lavaan`, as any core or external improvement or modernation for `lavaan`-based functionality can thereby benefit `dySEM`. McNeish’s work (McNeish et al., 2018), for example, has brought appropriate renewed attention to the limits of depending on the cutoffs for model fit indexes that were popularized, most successfully, by Hu and Bentler (Hu & Bentler, 1999). Subsequently, McNeish and colleagues have provided `lavaan`-friendly functionality to calculate so-called “dynamic” fit indexes, which identify simulation-generated targets for model fit indexes that are calibrated to a given fitted model (McNeish, 2023; McNeish & Manapat, 2024; McNeish & Wolf, 2022, 2023). More recently, McNeish and Wolf have proposed Direct Discrepancy Dynamic Fit Index (“DD-DFI” or “3DFI”) cutoffs, which are robust in application across many kinds of fitted models, response scales, estimators, and missing data conditions (McNeish & Wolf, 2024). And with their `dynamic` package for R, **it is quite straightforward to use 3DFIs, with** ***dySEM***, **to perform a more rigorous appraisal of the fit of our selected L-APIMs: a practice that, whenever possible, we recommend as the default approach for the appraisal of dyadic SEMs with** ***dySEM*** **when their features match the requirements of 3DFIs**—namely, in the absence of a mean structure. 
 
 To evaluate the dynamic fit of our selected L-APIM, we can quickly re-fit it without a mean structure (to make it appropriate for calculating 3DFIs) using the optional  `includeMeanStruct` argument (and setting it to `FALSE`) for `scriptAPIM()`, which will ensure no intercepts or latent means are estimated (you can verify this for yourself with `summary()`):
 
@@ -180,15 +182,15 @@ apim.script.free.actpart.noms <-  scriptAPIM(apim_dvn, lvxname = "Sat", lvyname 
 apim.fit.free.actpart.noms <- cfa(apim.script.free.actpart.noms, data = com_dat)
 ```
 
-Then, it's as simple as supplying the fitted *lavaan* model to the *dynamic* package's `DDDFI()` function. Because this is a simulation-based function, it's good practice to set a random seed (to ensure you can get the same numeric results from run to run): 
+Then, it's as simple as supplying the fitted `lavaan` model to the `dynamic` package's `DDDFI()` function. Because this is a simulation-based function, it's good practice to set a random seed (to ensure you can get the same numeric results from run to run): 
 
 ```{r calc 3DFIS, echo = TRUE, eval = FALSE}
 set.seed(519)
 DDDFI(apim.fit.free.actpart.noms)
 ```
 
-**Note**: since the `DDDFI()` function is not yet in the CRAN version of dynamic, we can't reproducibly run it and include the output here, in this automatically compiling online tutorial, but you can run this code in your own R session to see the results.
+**Note**: since the `DDDFI()` function is not yet in the CRAN version of `dynamic`, we can't reproducibly run it and include the output here, in this automatically compiling online tutorial, but you can run this code in your own R session to see the results.
 
-Based on these 3DFI targets, both our observed model fit values of RMSEA = `r round(mis_actpart[1], 3)` and CFI = `r round(mis_actpart[2],3)` fall between the "Fair" and "Mediocre" level of fit. This is likely driven (in part) by exceptionally low loading values observed for some of the commitment items (which we would further explore, if this were a real analysis and we were so inclined)
+Based on these 3DFI targets, both our observed model fit values of RMSEA = `r round(mis_actpart[1], 3)` and CFI = `r round(mis_actpart[2],3)` fall between the "Fair" and "Mediocre" level of fit. This is likely driven (in part) by exceptionally low loading values observed for some of the commitment items (which we would further explore, if this were a real analysis and we were so inclined).
 
 

--- a/vignettes/articles/M-CDFM.Rmd
+++ b/vignettes/articles/M-CDFM.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Fitting and Interpretting the Multiple Correlated Dyadic Factors Model (M-CDFM)"
+title: "Fitting and Interpreting the Multiple Correlated Dyadic Factors Model (M-CDFM)"
 ---
 
 ```{r, include = FALSE}
@@ -15,15 +15,15 @@ This tutorial is a supplemental material from the following article:
 
 Sakaluk, J. K., & Camanto, O. J. (2025). *Dyadic Data Analysis via Structural Equation Modeling with Latent Variables: A Tutorial with the dySEM package for R*. 
 
-This article is intended to serve as the primary citation of record for the dySEM package's functionality for the techniques described in this tutorial. **If this tutorial has informed your modeling strategy (including but not limited to your use of `dySEM`), please cite this article**. 
+This article is intended to serve as the primary citation of record for the `dySEM` package's functionality for the techniques described in this tutorial. **If this tutorial has informed your modeling strategy (including but not limited to your use of `dySEM`), please cite this article**. 
 
-The citation of research software aiding in analyses--like the use of `dySEM`--is a required practice, according to the Journal Article Reporting Standards (JARS) for Quantitative Research in Psychology ([Appelbaum et al., 2018](https://psycnet.apa.org/fulltext/2018-00750-002.html)). 
+The citation of research software aiding in analyses---like the use of `dySEM`---is a required practice, according to the Journal Article Reporting Standards (JARS) for Quantitative Research in Psychology ([Appelbaum et al., 2018](https://psycnet.apa.org/fulltext/2018-00750-002.html)). 
 
 Furthermore, citations remain essential for our development team to demonstrate the impact of our work to our local institutions and our funding sources, and with your support, we will be able to continue justifying our time and efforts spent improving `dySEM` and expanding its reach. 
 
 ## Overview
 
-The M-CDFM is a **"multi-construct"** dyadic SEM (i.e., used to represent dyadic data about more than two constructs--like different features of relationship quality, e.g., Fletcher et al., 2000). 
+The M-CDFM is a **"multi-construct"** dyadic SEM (i.e., used to represent dyadic data about more than two constructs---like different features of relationship quality, e.g., Fletcher et al., 2000). 
 
 It contains:
 
@@ -41,6 +41,8 @@ The M-CDFM is typically the model people mean when they refer to "dyadic CFA", t
 
 ## Packages and Data
 
+This exemplar makes use of the `dplyr`, `gt`, `dySEM`, and `lavaan` (Rosseel, 2012) packages.
+
 ```{r setup, message= FALSE}
 
 library(dplyr) #for data management
@@ -49,7 +51,7 @@ library(dySEM) #for dyadic SEM scripting and outputting
 library(lavaan) #for fitting dyadic SEMs
 ```
 
-For this exemplar, we use two built-in datasets from dySEM (focusing more on one). Of primary interest, the imsM dataset corresponds to data from the “global” items from 282 mixed-sex couples responding to the full Rusbult et al. (1998) Investment Model Scale (including 5 items each for satisfaction, quality of alternatives, investment, and commitment). More information about this data set can be found in [Sakaluk et al. (2021)](https://doi.org/10.1111/pere.12341).
+For this exemplar, we use two built-in datasets from `dySEM` (focusing more on one). Of primary interest, the [`imsM`](https://jsakaluk.github.io/dySEM/reference/imsM.html) dataset corresponds to data from the “global” items from 282 mixed-sex couples responding to the full Rusbult et al. (1998) Investment Model Scale (IMS) (including 5 items each for satisfaction, quality of alternatives, investment, and commitment). More information about this data set can be found in [Sakaluk et al. (2021)](https://doi.org/10.1111/pere.12341).
 
 All variables in this data frame follow a [“sip” naming pattern]((https://jsakaluk.github.io/dySEM/articles/varnames.html)):
 
@@ -61,9 +63,9 @@ imsM_dat |>
   as_tibble()
 ```
 
-We will also use data from the prqcQ dataset, which contains data from 118 queer couples responding to the Perceived Relationship Quality Components Inventory (Fletcher et al., 2000) (including 3 items each for satisfaction, commitment, intimacy, trust, passion, and love). While substantive analyses of this data set have not yet been reported, the data collection took place in parallel to the analyses reported in [Sakaluk et al. (2021)](https://doi.org/10.1111/pere.12341).
+We will also use data from the [`prqcQ`](https://jsakaluk.github.io/dySEM/reference/prqcQ.html) dataset, which contains data from 118 queer couples responding to the Perceived Relationship Quality Components Inventory (Fletcher et al., 2000) (including 3 items each for satisfaction, commitment, intimacy, trust, passion, and love). While substantive analyses of this data set have not yet been reported, the data collection took place in parallel to the analyses reported in [Sakaluk et al. (2021)](https://doi.org/10.1111/pere.12341).
 
-In contrast to imsM, variable names in the prqcQ data frame follow the [“spi” naming pattern](https://jsakaluk.github.io/dySEM/articles/varnames.html):
+In contrast to `imsM`, variable names in the `prqcQ` data frame follow the [“spi” naming pattern](https://jsakaluk.github.io/dySEM/articles/varnames.html):
 
 ```{r, tibble prqc, echo = TRUE}
 
@@ -75,19 +77,19 @@ prqc_dat |>
 
 ## 1. Scraping the Variables
 
-Users will take note that the imsM dataset contains variabels for items for which there are distinctive stems for each subscale (e.g., "sat", "invest", "com"), whereas the prqcQ dataset contains a repetitive uninformative stem ("prqc"), despite the presence of multidimensionality. Rest assured, `scrapeVarCross()` has been developed with functionality to scrape variable information from both kinds of stems from multidimensional instruments. Further, scraping variable information remains relatively straightforward (and the key to unlocking the powerful functionality of *dySEM*'s scripters), with just one added "twist" from the simpler case of uni-construct or bi-construct models: the creation of a *named list* spelling out the naming 'formula' for each set of indicators.
+Users will take note that the `imsM` dataset contains variables for items for which there are distinctive stems for each subscale (e.g., "sat", "invest", "com"), whereas the `prqcQ` dataset contains a repetitive uninformative stem ("prqc"), despite the presence of multidimensionality. Rest assured, [`scrapeVarCross()`](https://jsakaluk.github.io/dySEM/reference/scrapeVarCross.html) has been developed with functionality to scrape variable information from both kinds of stems from multidimensional instruments. Further, scraping variable information remains relatively straightforward (and the key to unlocking the powerful functionality of `dySEM`'s scripters), with just one added "twist" from the simpler case of uni-construct or bi-construct models: the creation of a *named list* spelling out the naming 'formula' for each set of indicators.
 
 
 ### Distinctive Indicator Stems
 
-The case when indicators have distinctive stems--usually indicating the putative factor onto which they load (e.g., "sat", "com")--is the most straightforward to scrape with `scrapeVarCross()`. 
+The case when indicators have distinctive stems---usually indicating the putative factor onto which they load (e.g., "sat", "com")---is the most straightforward to scrape with `scrapeVarCross()`. 
 
 In this case, users will need to provide the names of the latent variables, the stem for each set of indicators, and the delimiters used in the variable names. In the case of the `imsM` exemplar (i.e., when stems are distinct), the named list must contain the following four elements/vectors (and the names of these elements/vectors must follow what is shown below):
 
 - **lvnames**: a vector of the (arbitrary) names that will be used for the latent variables in the `lavaan` script
-- **stem**: a vector containing each distinctive stem for each set of indicators (e.g., "sat.g", "qalt.g", "invest.g", "com")-- `scrapeVarCross()` will use these to search for indicators with matching stems
-- **delim1**: a vector containing the first delimiter used in the variable names (e.g., "", "", "", "")-- `scrapeVarCross()` will use these to search for indicators with matching patterns of delimination
-- **delim2**: a vector containing the second delimiter used in the variable names (e.g., "_", "_", "_", "_")-- `scrapeVarCross()` will use these to search for indicators with matching patterns of delimination
+- **stem**: a vector containing each distinctive stem for each set of indicators (e.g., "sat.g", "qalt.g", "invest.g", "com")--- `scrapeVarCross()` will use these to search for indicators with matching stems
+- **delim1**: a vector containing the first delimiter used in the variable names (e.g., "", "", "", "")--- `scrapeVarCross()` will use these to search for indicators with matching patterns of delimination
+- **delim2**: a vector containing the second delimiter used in the variable names (e.g., "_", "_", "_", "_")--- `scrapeVarCross()` will use these to search for indicators with matching patterns of delimination
 
 Each of these elements/vectors must be of the same length, and the order of the elements in each vector must correspond to the order of the latent variables in `lvnames`. And so, saving this named list (in essence, the "recipe card" of indicator names for each factor) into its own object:
 
@@ -112,7 +114,7 @@ distinguish_2 = "m")
 
 ```
 
-The resulting *dvn* remains as unremarkable as ever, but continues to serve as the foundation for unlocking the functionality of multi-construct scripters in *dySEM*. The only difference from the one-construct use-case of `scrapeVarCross()` is that the `$p1xvarnames` and `$p2xvarnames` elements now contain a nested set of vectors of variable names (as opposed to only set of variable names):
+The resulting *dvn* remains as unremarkable as ever, but continues to serve as the foundation for unlocking the functionality of multi-construct scripters in `dySEM`. The only difference from the one-construct use-case of `scrapeVarCross()` is that the `$p1xvarnames` and `$p2xvarnames` elements now contain a nested set of vectors of variable names (as opposed to only set of variable names):
 
 ```{r, ims dvn, echo = TRUE}
 
@@ -122,11 +124,11 @@ dvnIMS
 
 ### Non-Distinctive Indicator Stems
 
-The case when indicators have non-distinctive stems only requires that your named list--that you later supply to `scrapeVarCross()`--has two more elements/vectors. Currently, **this functionality assumes indicators from the same latent variable (e.g., items measuring Satisfaction) are clustered together, sequentially, in item number (e.g., prqc.1_1 prqc.1_2 prqc.1_3) rather than being interspersed with items from other latent variables (e.g., prqc.1_1 prqc.1_5, prqc.1_8)**.
+The case when indicators have non-distinctive stems only requires that your named list---that you later supply to `scrapeVarCross()`---has two more elements/vectors. Currently, **this functionality assumes indicators from the same latent variable (e.g., items measuring Satisfaction) are clustered together, sequentially, in item number (e.g., prqc.1_1 prqc.1_2 prqc.1_3) rather than being interspersed with items from other latent variables (e.g., prqc.1_1 prqc.1_5, prqc.1_8)**.
 
 The additional arguments that must be added to the named list are:
 
-- **min_num**: a vector containing the item number in the sequence of non-destinctively named indicators that corresponds to the first item for each latent variable (e.g., 1, 4, 7, 10, 13, 16 for Satisfaction, Commitment, Intimacy, Trust, Passion, and Love, respectively), and
+- **min_num**: a vector containing the item number in the sequence of non-distinctively named indicators that corresponds to the first item for each latent variable (e.g., 1, 4, 7, 10, 13, 16 for Satisfaction, Commitment, Intimacy, Trust, Passion, and Love, respectively), and
 - **max_num**: a vector containing the item number in the sequence of non-distinctively named indicators that corresponds to the last item for each latent variable (e.g., 3, 6, 9, 12, 15, 18 for Satisfaction, Commitment, Intimacy, Trust, Passion, and Love, respectively).
 
 ```{r, prqc list, echo = TRUE}
@@ -153,13 +155,13 @@ distinguish_2 = "2")
 dvnPRQC
 ```
 
-Whether your *dvn* contains variable information for indicators with distinctive or non-distinctive stems makes no difference to the functionality you can draw upon from *dySEM*, or how you pass this information to scripters--it remains the same (and straightforward) for both kinds of indicators. 
+Whether your *dvn* contains variable information for indicators with distinctive or non-distinctive stems makes no difference to the functionality you can draw upon from `dySEM`, or how you pass this information to scripters---it remains the same (and straightforward) for both kinds of indicators. 
 
 ## 2. Scripting the Model(s)
 
-Continuing with the `imsM` exemplar for this rest of this vignette, we can now quickly script a series of M-CDFMs using the `scriptCFA()` function (so named given that most imagine a M-CDFM model when conducting "dyadic CFA"), and incrementally layer on more dyadic invariance constraints via the `constr_dy_meas` argument. 
+Continuing with the `imsM` exemplar for this rest of this vignette, we can now quickly script a series of M-CDFMs using the [`scriptCFA()`](https://jsakaluk.github.io/dySEM/reference/scriptCFA.html) function (so named given that most imagine a M-CDFM model when conducting "dyadic CFA"), and incrementally layer on more dyadic invariance constraints via the `constr_dy_meas` argument. 
 
-The `writeTo` and `fileName` arguments (not depicted here) remain available to those wanting to export a .txt file of their concatenated `lavaan` script(s) (e.g., for posting on the OSF). `scaleset` remains fixed-factor, by default, but this is changeable to marker-variable ("MV") for those interested. Given the consequential nature of this choice (e.g., for interpreting the scale of parameter estimates), we strongly recommend making this argument explicit (despite its implicit default to "FF"):
+The `writeTo` and `fileName` arguments (not depicted here) remain available to those wanting to export a `.txt` file of their concatenated `lavaan` script(s) (e.g., for posting on the OSF). `scaleset` remains fixed-factor, by default, but this is changeable to marker-variable ("MV") for those interested. Given the consequential nature of this choice (e.g., for interpreting the scale of parameter estimates), we strongly recommend making this argument explicit (despite its implicit default to "FF"):
 
 ```{r, script ims, echo = TRUE}
 
@@ -174,7 +176,7 @@ script.ims.res <-  scriptCFA(dvnIMS, scaleset = "FF",constr_dy_meas = c("loading
 
 ```
 
-You can concatenate these scripts, if you wish, using the base `cat()` function, to make them more human-readable in your console, but beware: the amount of `lavaan` scripting is considerabel (and therefore we do not show what it returns here):
+You can concatenate these scripts, if you wish, using the base `cat()` function, to make them more human-readable in your console, but beware: the amount of `lavaan` scripting is considerable (and therefore we do not show what it returns here):
 
 ```{r, cat ims script, include = TRUE, eval = FALSE}
 
@@ -185,7 +187,7 @@ cat(script.ims.config)
 
 ## 3. Fitting the Model(s) 
 
-All of these models can now be fit with whichever lavaan wrapper the user prefers, and with their chosen analytic options (e.g., estimator, missing data treatment, etc.); our demonstration uses default specifications for `cfa()`: 
+All of these models can now be fit with whichever `lavaan` wrapper the user prefers, and with their chosen analytic options (e.g., estimator, missing data treatment, etc.); our demonstration uses default specifications for `cfa()`: 
 
 ```{r, fit ims, echo = TRUE}
 
@@ -202,14 +204,14 @@ ims.res.mod <- cfa(script.ims.res, data = imsM_dat)
 
 ## 4. Outputting and Interpreting the Model(s)
 
-As with the CDFM, competing nested M-CDFMs--like for dyadic invariance testing with a larger measure--can be compared with the base `anova()` function:
+As with the [CDFM](https://jsakaluk.github.io/dySEM/articles/CDFM.html), competing nested M-CDFMs---like for dyadic invariance testing with a larger measure---can be compared with the base `anova()` function:
 
 ```{r, anova ims, echo = TRUE}
 
 anova(ims.config.mod, ims.load.mod, ims.int.mod, ims.res.mod)
 ```
 
-Or, for a more reproducible-reporting-friendly option, *dySEM*'s `outputInvarComp()` function is available, and amenable to other tabling packages/functions (e.g., `gt::gt()`, as we demonstrate below), and/or can write an .rtf if the user makes use of the `writeTo` and `fileName` arguments:
+Or, for a more reproducible-reporting-friendly option, `dySEM`'s [`outputInvarCompTab()`](https://jsakaluk.github.io/dySEM/reference/outputInvarCompTab.html) function is available, and amenable to other tabling packages/functions (e.g., `gt::gt()`, as we demonstrate below), and/or can write an `.rtf` if the user makes use of the `writeTo` and `fileName` arguments:
 
 ```{r, invarcomp ims, echo = TRUE}
 
@@ -230,9 +232,9 @@ p <- round(comp$pr_chisq, 2)
 
 ```
 
-Were one strictly to follow only the likelihood ratio test statistic as a guide, they would reject the possibility of the relatively low bar of loading invariance for the IMQ, $\chi^2$ (`r comp$df_diff[2]`) = `r chisq_diff[2]`, *p* `r if(p[2] < .001){paste("<.001")}`. Of course, other methods of model comparison and selection (and their respective thresholds) are available, and whatever method is chosen probably ought to be preregistered. 
+Were one strictly to follow only the likelihood ratio test statistic as a guide, they would reject the possibility of the relatively low bar of loading invariance for the IMS, $\chi^2$ (`r comp$df_diff[2]`) = `r chisq_diff[2]`, *p* `r if(p[2] < .001){paste("<.001")}`. Of course, other methods of model comparison and selection (and their respective thresholds) are available, and whatever method is chosen probably ought to be preregistered. 
 
-Meanwhile, the standard outputters from *dySEM* are available to help researchers either table and/or visualize their results. Given the complexity of the M-CDFM (often many more factors and items) than the CDFM, we recommend tabling (vs. visualizing) model output:
+Meanwhile, the standard outputters from `dySEM` are available to help researchers either table and/or visualize their results. Given the complexity of the M-CDFM (often many more factors and items) than the CDFM, we recommend tabling (vs. visualizing) model output:
 
 ```{r, tables ims, echo = TRUE}
 
@@ -253,7 +255,7 @@ outputParamTab(dvn = dvnIMS, model = "cfa", fit = ims.config.mod,
 
 ## 5. Optional Indexes and Output
 
-Finally, like with the CDFM, users can use additional *dySEM* functions to output additional information about their model, such as the computation of Langrange multiplier tests to identify for which items and measurement model parameters there is significant nonivariance:
+Finally, like with the CDFM, users can use additional `dySEM` functions to output additional information about their model, such as the computation of Lagrange multiplier tests to identify for which items and measurement model parameters there is significant noninvariance:
 
 ```{r ims noninvariance, echo = TRUE}
 


### PR DESCRIPTION
Addresses Issue #142 

This PR includes minor documentation cleanup across the CDFM, M-CDFM, and L-APIM tutorials.

Changes include:
- Minor phrasing polish (e.g., spelling touch-ups)
- Standardization of inline code styling (e.g., function/object references and hyperlinks)
- Light adjustments for consistency (e.g., package references)