### PR TITLE
fix: resolve error for `constr_dy_meas="loadings"` with `scaleset="MV"` in `scriptCFA()`

### DIFF
--- a/R/scriptCFA.R
+++ b/R/scriptCFA.R
@@ -176,7 +176,7 @@ scriptCFA <- function(dvn, scaleset = "FF",
       x1loads <- multifac_loads(dvn, partner = "1", type = "equated")
       x2loads <- multifac_loads(dvn, partner = "2", type = "equated")
     } else if (scaleset == "MV") {
-      xloads1 <- multifac_loads(dvn, partner = "1", type = "fixed")
+      x1loads <- multifac_loads(dvn, partner = "1", type = "fixed")
       x2loads <- multifac_loads(dvn, partner = "2", type = "equated")
     }
   } else {


### PR DESCRIPTION
Addresses Issue #146 

This PR fixes an error in `scriptCFA()` that occurred when requesting loading invariance (`constr_dy_meas = "loadings"`) with marker-variable scale setting (`scaleset = "MV"`). The fix involved correcting a small object-naming typo in the `constr_dy_meas="loadings"` + `scaleset="MV"` path (i.e., changing `xloads1` to `x1loads`).